### PR TITLE
Adds ability to register custom tag providers

### DIFF
--- a/src/htmlLanguageService.ts
+++ b/src/htmlLanguageService.ts
@@ -14,6 +14,7 @@ import {findDocumentHighlights} from './services/htmlHighlighting';
 import {TextDocument, Position, CompletionItem, CompletionList, Hover, Range, SymbolInformation, Diagnostic, TextEdit, DocumentHighlight, FormattingOptions, MarkedString, DocumentLink } from 'vscode-languageserver-types';
 
 export {TextDocument, Position, CompletionItem, CompletionList, Hover, Range, SymbolInformation, Diagnostic, TextEdit, DocumentHighlight, FormattingOptions, MarkedString, DocumentLink };
+export {HTMLTagProvider, registerTagProvider} from './services/tagProviders';
 
 export interface HTMLFormatConfiguration {
 	tabSize: number;

--- a/src/services/tagProviders.ts
+++ b/src/services/tagProviders.ts
@@ -13,3 +13,20 @@ export let allTagProviders : IHTMLTagProvider[] = [
 	getIonicTagProvider(),
 	getRazorTagProvider()
 ];
+
+export {IHTMLTagProvider as HTMLTagProvider} from '../parser/htmlTags';
+
+export function registerTagProvider(tagProvider: IHTMLTagProvider) {
+	const index = findIndex(allTagProviders, p => p.getId() === tagProvider.getId());
+	if (index >= 0) {
+		allTagProviders.splice(index, 1);
+	}
+	allTagProviders.push(tagProvider);
+}
+
+function findIndex(array: Array<any>, predicate: (item: any, index: number) => boolean) {
+	for (let i = 0; i < array.length; i++) {
+		if (predicate(array[i], i)) return i;
+	}
+	return -1;
+}


### PR DESCRIPTION
This will hopefully allow other extensions to extend the html parsing with their own tags -- for example https://github.com/aurelia/vscode-extension
