### PR TITLE
Add findDocumentSymbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ and the Monaco editor.
  - *doComplete* provides completion proposals for a given location.
  - *findDocumentHighlights* provides the highlighted symbols for a given position
  - *format* formats the code at the given range.
- - *findDocumentLinks* finds al links in the document
+ - *findDocumentLinks* finds all links in the document
+ - *findDocumentSymbols* finds all the symbols in the document
 
 Installation
 ------------

--- a/src/htmlLanguageService.ts
+++ b/src/htmlLanguageService.ts
@@ -11,6 +11,7 @@ import {doHover} from './services/htmlHover';
 import {format} from './services/htmlFormatter';
 import {findDocumentLinks} from './services/htmlLinks';
 import {findDocumentHighlights} from './services/htmlHighlighting';
+import {findDocumentSymbols} from './services/htmlSymbolsProvider';
 import {TextDocument, Position, CompletionItem, CompletionList, Hover, Range, SymbolInformation, Diagnostic, TextEdit, DocumentHighlight, FormattingOptions, MarkedString, DocumentLink } from 'vscode-languageserver-types';
 
 export {TextDocument, Position, CompletionItem, CompletionList, Hover, Range, SymbolInformation, Diagnostic, TextEdit, DocumentHighlight, FormattingOptions, MarkedString, DocumentLink };
@@ -113,6 +114,7 @@ export interface LanguageService {
 	doHover(document: TextDocument, position: Position, htmlDocument: HTMLDocument): Hover;
 	format(document: TextDocument, range: Range, options: HTMLFormatConfiguration): TextEdit[];
 	findDocumentLinks(document: TextDocument, documentContext: DocumentContext): DocumentLink[];
+	findDocumentSymbols(document: TextDocument, htmlDocument: HTMLDocument): SymbolInformation[];
 }
 
 export function getLanguageService(): LanguageService {
@@ -123,6 +125,7 @@ export function getLanguageService(): LanguageService {
 		doHover,
 		format,
 		findDocumentHighlights,
-		findDocumentLinks
+		findDocumentLinks,
+		findDocumentSymbols
 	};
 }

--- a/src/services/htmlSymbolsProvider.ts
+++ b/src/services/htmlSymbolsProvider.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import {TextDocument, Position, Location, Range, SymbolInformation, SymbolKind} from 'vscode-languageserver-types';
+import {HTMLDocument, Node} from '../parser/htmlParser';
+import {TokenType, createScanner, ScannerState} from '../parser/htmlScanner';
+
+export function findDocumentSymbols(document: TextDocument, htmlDocument: HTMLDocument): SymbolInformation[] {
+	let symbols = <SymbolInformation[]>[];
+
+	htmlDocument.roots.forEach(node => {
+		provideFileSymbolsInternal(document, node, '', symbols)
+	});
+
+	return symbols;
+}
+
+function provideFileSymbolsInternal(document: TextDocument, node: Node, container: string, symbols: SymbolInformation[]): void {
+
+	let name = nodeToName(node);
+	let location = Location.create(document.uri, Range.create(document.positionAt(node.start), document.positionAt(node.end)));
+	let symbol = <SymbolInformation> {
+		name: name,
+		location: location,
+		containerName: container,
+		kind: <SymbolKind>SymbolKind.Field
+	}
+
+	symbols.push(symbol);
+
+	node.children.forEach(child => {
+		provideFileSymbolsInternal(document, child, name, symbols);
+	});
+}
+
+
+function nodeToName(node: Node): string {
+	let name = node.tag;
+
+	if (node.attributes) {
+		let id = node.attributes['id'];
+		let classes = node.attributes['class'];
+		
+		if (id) {
+			name += `#${id.replace(/[\"\']/g, '')}`;
+		}
+
+		if (classes) {
+			name += classes.replace(/[\"\']/g, '').split(/\s+/).map(className => `.${className}`).join('');
+		}
+	}
+
+	return name;
+}

--- a/src/test/symbols.test.ts
+++ b/src/test/symbols.test.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import * as assert from 'assert';
+import * as htmlLanguageService from '../htmlLanguageService';
+
+import { TextDocument, SymbolInformation, SymbolKind, Location, Range, Position } from 'vscode-languageserver-types';
+
+suite('HTML Symbols', () => {
+
+    const TEST_URI = "test://test/test.html";
+
+	function asPromise<T>(result: T): Promise<T> {
+		return Promise.resolve(result);
+	}
+
+    let assertSymbols = function (symbols: SymbolInformation[], expected: SymbolInformation[]) {
+        assert.deepEqual(symbols, expected);
+    }
+
+    let testSymbolsFor = function(value: string, expected: SymbolInformation[]) {
+        let ls = htmlLanguageService.getLanguageService();
+		let document = TextDocument.create(TEST_URI, 'html', 0, value);
+		let htmlDoc = ls.parseHTMLDocument(document);
+        let symbols = ls.findDocumentSymbols(document, htmlDoc);
+        assertSymbols(symbols, expected);
+    }
+
+    test('Simple', () => {
+        testSymbolsFor('<div></div>', [<SymbolInformation>{ containerName: '', name: 'div', kind: <SymbolKind>SymbolKind.Field, location: Location.create(TEST_URI, Range.create(0, 0, 0, 11)) }]);
+        testSymbolsFor('<div><input checked id="test" class="checkbox"></div>', [{ containerName: '', name: 'div', kind: <SymbolKind>SymbolKind.Field, location: Location.create(TEST_URI, Range.create(0, 0, 0, 53)) },
+            { containerName: 'div', name: 'input#test.checkbox', kind: <SymbolKind>SymbolKind.Field, location: Location.create(TEST_URI, Range.create(0, 5, 0, 47)) }]);
+    });
+})


### PR DESCRIPTION
A question was asked in gitter if VS Code has an equivalent of WebStorm's ["File Structure Popup"](https://youtu.be/7Ai8966qny0?t=39) in HTML. The closest that vscode has is "Show document symbols", but the html language service does not provide that.

To attempt parity with webstorm in this area, I have implemented findDocumentSymbols. I have augmented the parser to track tag attributes and their values (I could see nowhere before that attributes were being used) and combine the tag name with id and class attributes to build a symbol name.

For example, `<div id='test' class='my classes'></div>` will have the symbol name `div#id.my.classes`. For child elements, I set the containerName to be the symbol name of their parent tag. So in `<div id='container1'><span></span></div>`, the span element would have the symbol name `span` and the container name `div#container1`

I set the SymbolKind to field just to have something as I am unsure what the convention is for non-code related symbols.

For this to appear in vscode, it would necessitate a change there as well. I have a pull request ready to submit if this is accepted.