### PR TITLE
Enable strict mode compile

### DIFF
--- a/src/htmlLanguageService.ts
+++ b/src/htmlLanguageService.ts
@@ -32,8 +32,8 @@ export interface HTMLFormatConfiguration {
 }
 
 export interface CompletionConfiguration {
-	[provider: string]: boolean;
-	hideAutoCompleteProposals?: boolean
+	[provider: string]: boolean | undefined;
+	hideAutoCompleteProposals?: boolean;
 }
 
 export interface Node {
@@ -42,8 +42,8 @@ export interface Node {
 	end: number;
 	endTagStart: number;
 	children: Node[];
-	parent: Node;
-	attributes?: {[name: string]: string};
+	parent: Node | null;
+	attributes?: {[name: string]: string | null};
 }
 
 
@@ -93,7 +93,7 @@ export interface Scanner {
 	getTokenLength(): number;
 	getTokenEnd(): number;
 	getTokenText(): string;
-	getTokenError(): string;
+	getTokenError(): string | undefined;
 	getScannerState(): ScannerState;
 }
 
@@ -112,11 +112,11 @@ export interface LanguageService {
 	parseHTMLDocument(document: TextDocument): HTMLDocument;
 	findDocumentHighlights(document: TextDocument, position: Position, htmlDocument: HTMLDocument): DocumentHighlight[];
 	doComplete(document: TextDocument, position: Position, htmlDocument: HTMLDocument, options?: CompletionConfiguration): CompletionList;
-	doHover(document: TextDocument, position: Position, htmlDocument: HTMLDocument): Hover;
+	doHover(document: TextDocument, position: Position, htmlDocument: HTMLDocument): Hover | undefined;
 	format(document: TextDocument, range: Range, options: HTMLFormatConfiguration): TextEdit[];
 	findDocumentLinks(document: TextDocument, documentContext: DocumentContext): DocumentLink[];
 	findDocumentSymbols(document: TextDocument, htmlDocument: HTMLDocument): SymbolInformation[];
-	doTagComplete(document: TextDocument, position: Position, htmlDocument: HTMLDocument): string;
+	doTagComplete(document: TextDocument, position: Position, htmlDocument: HTMLDocument): string | null;
 }
 
 export function getLanguageService(): LanguageService {

--- a/src/parser/htmlScanner.ts
+++ b/src/parser/htmlScanner.ts
@@ -106,7 +106,7 @@ class MultiLineStream {
 		let str = this.source.substr(this.position);
 		let match = str.match(regex);
 		if (match) {
-			this.position = this.position + match.index + match[0].length;
+			this.position = this.position + match.index! + match[0].length;
 			return match[0];
 		}
 		return '';
@@ -116,7 +116,7 @@ class MultiLineStream {
 		let str = this.source.substr(this.position);
 		let match = str.match(regex);
 		if (match) {
-			this.position = this.position + match.index;
+			this.position = this.position + match.index!;
 			return match[0];
 		} else {
 			this.goToEnd();
@@ -199,7 +199,7 @@ export interface Scanner {
 	getTokenLength(): number;
 	getTokenEnd(): number;
 	getTokenText(): string;
-	getTokenError(): string;
+	getTokenError(): string | undefined;
 	getScannerState(): ScannerState;
 }
 
@@ -212,13 +212,13 @@ export function createScanner(input: string, initialOffset = 0, initialState: Sc
 	let stream = new MultiLineStream(input, initialOffset);
 	let state = initialState;
 	let tokenOffset: number = 0;
-	let tokenType: number = void 0;
-	let tokenError: string;
+	let tokenType: number | undefined = void 0;
+	let tokenError: string | undefined;
 
 	let hasSpaceAfterTag: boolean;
 	let lastTag: string;
-	let lastAttributeName: string;
-	let lastTypeValue: string;
+	let lastAttributeName: string | null;
+	let lastTypeValue: string | null;
 
 	function nextElementName(): string {
 		return stream.advanceIfRegExp(/^[_:\w][_:\w-.\d]*/).toLowerCase();
@@ -352,7 +352,7 @@ export function createScanner(input: string, initialOffset = 0, initialState: Sc
 				}
 				if (stream.advanceIfChar(_RAN)) { // >
 					if (lastTag === 'script') {
-						if (lastTypeValue && htmlScriptContents[lastTypeValue]) {
+						if (lastTypeValue && (htmlScriptContents as any)[lastTypeValue]) {
 							// stay in html
 							state = ScannerState.WithinContent;
 						} else {
@@ -455,7 +455,7 @@ export function createScanner(input: string, initialOffset = 0, initialState: Sc
 	}
 	return {
 		scan,
-		getTokenType: () => tokenType,
+		getTokenType: () => tokenType!,
 		getTokenOffset: () => tokenOffset,
 		getTokenLength: () => stream.pos() - tokenOffset,
 		getTokenEnd: () => stream.pos(),

--- a/src/parser/htmlTags.ts
+++ b/src/parser/htmlTags.ts
@@ -42,15 +42,15 @@ let localize = nls.loadMessageBundle();
 export const EMPTY_ELEMENTS: string[] = ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'keygen', 'link', 'menuitem', 'meta', 'param', 'source', 'track', 'wbr'];
 
 export function isEmptyElement(e: string): boolean {
-	return e && arrays.binarySearch(EMPTY_ELEMENTS, e.toLowerCase(), (s1: string, s2: string) => s1.localeCompare(s2)) >= 0;
+	return e ? arrays.binarySearch(EMPTY_ELEMENTS, e.toLowerCase(), (s1: string, s2: string) => s1.localeCompare(s2)) >= 0 : false;
 }
 
 export interface IHTMLTagProvider {
 	getId(): string;
-	isApplicable(languageId: string);
+	isApplicable(languageId: string): boolean;
 	collectTags(collector: (tag: string, label: string) => void): void;
-	collectAttributes(tag: string, collector: (attribute: string, type: string) => void): void;
-	collectValues(tag: string, attribute: string, collector: (value: string) => void): void;
+	collectAttributes(tag: string | undefined, collector: (attribute: string, type: string | null) => void): void;
+	collectValues(tag: string | undefined, attribute: string, collector: (value: string) => void): void;
 }
 
 export interface ITagSet {
@@ -513,7 +513,7 @@ export function getAngularTagProvider(): IHTMLTagProvider {
 		collectTags: (collector: (tag: string, label: string) => void) => {
 			// no extra tags
 		},
-		collectAttributes: (tag: string, collector: (attribute: string, type: string) => void) => {
+		collectAttributes: (tag: string, collector: (attribute: string, type: string | null) => void) => {
 			if (tag) {
 				var attributes = customTags[tag];
 				if (attributes) {
@@ -560,7 +560,7 @@ export function getIonicTagProvider(): IHTMLTagProvider {
 		getId: () => 'ionic',
 		isApplicable: (languageId) => languageId === 'html',
 		collectTags: (collector: (tag: string, label: string) => void) => collectTagsDefault(collector, IONIC_TAGS),
-		collectAttributes: (tag: string, collector: (attribute: string, type: string) => void) => {
+		collectAttributes: (tag: string, collector: (attribute: string, type: string | null) => void) => {
 			collectAttributesDefault(tag, collector, IONIC_TAGS, globalAttributes);
 			if (tag) {
 				var attributes = customTags[tag];

--- a/src/parser/razorTags.ts
+++ b/src/parser/razorTags.ts
@@ -24,7 +24,7 @@ export function getRazorTagProvider() : IHTMLTagProvider {
 		collectTags: (collector: (tag: string, label: string) => void) => {
 			// no extra tags
 		},
-		collectAttributes: (tag: string, collector: (attribute: string, type: string) => void) => {
+		collectAttributes: (tag: string | undefined, collector: (attribute: string, type: string | null) => void) => {
 			if (tag) {
 				var attributes = customTags[tag];
 				if (attributes) {
@@ -32,7 +32,7 @@ export function getRazorTagProvider() : IHTMLTagProvider {
 				}
 			}
 		},
-		collectValues: (tag: string, attribute: string, collector: (value: string) => void) => {
+		collectValues: (tag: string | undefined, attribute: string, collector: (value: string) => void) => {
 			// no values
 		}
 	};

--- a/src/services/htmlFormatter.ts
+++ b/src/services/htmlFormatter.ts
@@ -69,7 +69,7 @@ export function format(document: TextDocument, range: Range, options: HTMLFormat
 
 	let result = html_beautify(value, htmlOptions);
 	if (initialIndentLevel > 0) {
-		let indent = options.insertSpaces ? repeat(' ', options.tabSize * initialIndentLevel) : repeat('\t', initialIndentLevel);
+		let indent = options.insertSpaces ? repeat(' ', (options.tabSize || 4) * initialIndentLevel) : repeat('\t', initialIndentLevel);
 		result = result.split('\n').join('\n' + indent);
 		if (range.start.character === 0) {
 			result = indent + result; // keep the indent
@@ -81,7 +81,7 @@ export function format(document: TextDocument, range: Range, options: HTMLFormat
 	}];
 }
 
-function getFormatOption(options: HTMLFormatConfiguration, key: string, dflt: any): any {
+function getFormatOption(options: HTMLFormatConfiguration, key: keyof HTMLFormatConfiguration, dflt: any): any {
 	if (options && options.hasOwnProperty(key)) {
 		let value = options[key];
 		if (value !== null) {
@@ -91,7 +91,7 @@ function getFormatOption(options: HTMLFormatConfiguration, key: string, dflt: an
 	return dflt;
 }
 
-function getTagsFormatOption(options: HTMLFormatConfiguration, key: string, dflt: string[]): string[] {
+function getTagsFormatOption(options: HTMLFormatConfiguration, key: keyof HTMLFormatConfiguration, dflt: string[] | undefined): string[] {
 	let list = <string>getFormatOption(options, key, null);
 	if (typeof list === 'string') {
 		if (list.length > 0) {
@@ -99,7 +99,7 @@ function getTagsFormatOption(options: HTMLFormatConfiguration, key: string, dflt
 		}
 		return [];
 	}
-	return dflt;
+	return dflt || [];
 }
 
 function computeIndentLevel(content: string, offset: number, options: HTMLFormatConfiguration): number {

--- a/src/services/htmlHighlighting.ts
+++ b/src/services/htmlHighlighting.ts
@@ -36,7 +36,7 @@ function covers(range: Range, position: Position) {
 	return isBeforeOrEqual(range.start, position) && isBeforeOrEqual(position, range.end);
 }
 
-function getTagNameRange(tokenType: TokenType, document: TextDocument, startOffset: number): Range {
+function getTagNameRange(tokenType: TokenType, document: TextDocument, startOffset: number): Range | null {
 	let scanner = createScanner(document.getText(), startOffset);
 	let token = scanner.scan();
 	while (token !== TokenType.EOS && token !== tokenType) {

--- a/src/services/htmlHover.ts
+++ b/src/services/htmlHover.ts
@@ -9,17 +9,17 @@ import { TokenType, createScanner } from '../parser/htmlScanner';
 import { TextDocument, Range, Position, Hover, MarkedString } from 'vscode-languageserver-types';
 import { allTagProviders } from './tagProviders';
 
-export function doHover(document: TextDocument, position: Position, htmlDocument: HTMLDocument): Hover {
+export function doHover(document: TextDocument, position: Position, htmlDocument: HTMLDocument): Hover | undefined {
 	let offset = document.offsetAt(position);
 	let node = htmlDocument.findNodeAt(offset);
 	if (!node || !node.tag) {
 		return void 0;
 	}
 	let tagProviders = allTagProviders.filter(p => p.isApplicable(document.languageId));
-	function getTagHover(tag: string, range: Range, open: boolean): Hover {
+	function getTagHover(tag: string, range: Range, open: boolean): Hover | undefined {
 		tag = tag.toLowerCase();
 		for (let provider of tagProviders) {
-			let hover: Hover;
+			let hover: Hover | undefined = undefined;
 			provider.collectTags((t, label) => {
 				if (t === tag) {
 					let tagLabel = open ? '<' + tag + '>' : '</' + tag + '>';
@@ -33,7 +33,7 @@ export function doHover(document: TextDocument, position: Position, htmlDocument
 		return void 0;
 	}
 
-	function getTagNameRange(tokenType: TokenType, startOffset: number): Range {
+	function getTagNameRange(tokenType: TokenType, startOffset: number): Range | null {
 		let scanner = createScanner(document.getText(), startOffset);
 		let token = scanner.scan();
 		while (token !== TokenType.EOS && (scanner.getTokenEnd() < offset || scanner.getTokenEnd() === offset && token !== tokenType)) {

--- a/src/services/htmlLinks.ts
+++ b/src/services/htmlLinks.ts
@@ -18,7 +18,7 @@ function stripQuotes(url: string): string {
 		.replace(/^"([^"]*)"$/, (substr, match1) => match1);
 }
 
-function getWorkspaceUrl(modelAbsoluteUri: Uri, tokenContent: string, documentContext: DocumentContext, base: string): string {
+function getWorkspaceUrl(modelAbsoluteUri: Uri, tokenContent: string, documentContext: DocumentContext, base: string | undefined): string | null {
 	if (/^\s*javascript\:/i.test(tokenContent) || /^\s*\#/i.test(tokenContent) || /[\n\r]/.test(tokenContent)) {
 		return null;
 	}
@@ -43,7 +43,7 @@ function getWorkspaceUrl(modelAbsoluteUri: Uri, tokenContent: string, documentCo
 	return tokenContent;
 }
 
-function createLink(document: TextDocument, documentContext: DocumentContext, attributeValue: string, startOffset: number, endOffset: number, base: string): DocumentLink {
+function createLink(document: TextDocument, documentContext: DocumentContext, attributeValue: string, startOffset: number, endOffset: number, base: string | undefined): DocumentLink | null {
 	let documentUri = Uri.parse(document.uri);
 	let tokenContent = stripQuotes(attributeValue);
 	if (tokenContent.length === 0) {
@@ -75,13 +75,13 @@ function isValidURI(uri: string) {
 export function findDocumentLinks(document: TextDocument, documentContext: DocumentContext): DocumentLink[] {
 	let newLinks: DocumentLink[] = [];
 
-	let rootAbsoluteUrl: Uri = null;
+	let rootAbsoluteUrl: Uri | null = null;
 
 	let scanner = createScanner(document.getText(), 0);
 	let token = scanner.scan();
 	let afterHrefOrSrc = false;
 	let afterBase = false;
-	let base = void 0;
+	let base: string | undefined = void 0;
 	while (token !== TokenType.EOS) {
 		switch (token) {
 			case TokenType.StartTag:

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -43,7 +43,7 @@ suite('HTML Completion', () => {
 			assert.equal(match.kind, expected.kind);
 		}
 		if (expected.resultText) {
-			assert.equal(applyEdits(document, [match.textEdit]), expected.resultText);
+			assert.equal(applyEdits(document, match.textEdit ? [match.textEdit] : []), expected.resultText);
 		}
 	};
 
@@ -68,7 +68,7 @@ suite('HTML Completion', () => {
 		return Promise.resolve();
 	};
 
-	let testTagCompletion = function (value: string, expected: string): void {
+	let testTagCompletion = function (value: string, expected: string | null): void {
 		let offset = value.indexOf('|');
 		value = value.substr(0, offset) + value.substr(offset + 1);
 
@@ -81,7 +81,7 @@ suite('HTML Completion', () => {
 		assert.equal(actual, expected);
 	};
 
-	function run(tests: PromiseLike<void>[], testDone) {
+	function run(tests: PromiseLike<void>[], testDone: (err?: any) => void) {
 		Promise.all(tests).then(() => {
 			testDone();
 		}, (error) => {

--- a/src/test/formatter.test.ts
+++ b/src/test/formatter.test.ts
@@ -12,7 +12,7 @@ import {applyEdits} from './textEditSupport';
 suite('JSON Formatter', () => {
 
 	function format(unformatted: string, expected: string, insertSpaces = true) {
-		let range: Range = null;
+		let range: Range | null = null;
 		let uri = 'test://test.html';
 
 		let rangeStart = unformatted.indexOf('|');
@@ -27,7 +27,7 @@ suite('JSON Formatter', () => {
 		}
 
 		var document = TextDocument.create(uri, 'html', 0, unformatted);
-		let edits = getLanguageService().format(document, range, { tabSize: 2, insertSpaces: insertSpaces, unformatted: '' });
+		let edits = getLanguageService().format(document, range!, { tabSize: 2, insertSpaces: insertSpaces, unformatted: '' });
 		let formatted  = applyEdits(document, edits);
 		assert.equal(formatted, expected);
 	}

--- a/src/test/highlighting.test.ts
+++ b/src/test/highlighting.test.ts
@@ -13,7 +13,7 @@ import {TextDocument} from 'vscode-languageserver-types';
 suite('HTML Highlighting', () => {
 
 
-	function assertHighlights(value: string, expectedMatches: number[], elementName: string): void {
+	function assertHighlights(value: string, expectedMatches: number[], elementName: string | null): void {
 		let offset = value.indexOf('|');
 		value = value.substr(0, offset) + value.substr(offset + 1);
 
@@ -29,7 +29,7 @@ suite('HTML Highlighting', () => {
 			let actualStartOffset = document.offsetAt(highlights[i].range.start);
 			assert.equal(actualStartOffset, expectedMatches[i]);
 			let actualEndOffset = document.offsetAt(highlights[i].range.end);
-			assert.equal(actualEndOffset, expectedMatches[i] + elementName.length);
+			assert.equal(actualEndOffset, expectedMatches[i] + (elementName ? elementName.length : 0));
 
 			assert.equal(document.getText().substring(actualStartOffset, actualEndOffset).toLowerCase(), elementName);
 		}

--- a/src/test/hover.test.ts
+++ b/src/test/hover.test.ts
@@ -12,7 +12,7 @@ import {TextDocument} from 'vscode-languageserver-types';
 
 suite('HTML Hover', () => {
 
-	function assertHover(value: string, expectedHoverLabel: string, expectedHoverOffset): void {
+	function assertHover(value: string, expectedHoverLabel: string | undefined, expectedHoverOffset: number | undefined): void {
 		let offset = value.indexOf('|');
 		value = value.substr(0, offset) + value.substr(offset + 1);
 
@@ -23,8 +23,8 @@ suite('HTML Hover', () => {
 		let htmlDoc = ls.parseHTMLDocument(document);
 
 		let hover = ls.doHover(document, position, htmlDoc);
-		assert.equal(hover && hover.contents[0].value, expectedHoverLabel);
-		assert.equal(hover && document.offsetAt(hover.range.start), expectedHoverOffset);
+		assert.equal(hover && (hover.contents as any[])[0].value, expectedHoverLabel);
+		assert.equal(hover && hover.range && document.offsetAt(hover.range.start), expectedHoverOffset);
 	}
 
 	test('Single', function (): any {

--- a/src/test/links.test.ts
+++ b/src/test/links.test.ts
@@ -23,7 +23,7 @@ suite('HTML Link Detection', () => {
 		}
 	}
 
-	function testLinkCreation(modelUrl: string, tokenContent: string, expected: string): void {
+	function testLinkCreation(modelUrl: string, tokenContent: string, expected: string | null): void {
 		let document = TextDocument.create(modelUrl, 'html', 0, `<a href="${tokenContent}">`);
 		let ls = htmlLanguageService.getLanguageService();
 		let links = ls.findDocumentLinks(document, getDocumentContext(modelUrl));

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -13,7 +13,7 @@ suite('HTML Parser', () => {
 		return { tag: node.tag, start: node.start, end: node.end, endTagStart: node.endTagStart, closed: node.closed, children: node.children.map(toJSON) };
 	}
 
-	function toJSONWithAttributes(node: Node) {
+	function toJSONWithAttributes(node: Node): any {
 		return { tag: node.tag, attributes: node.attributes, children: node.children.map(toJSONWithAttributes) };
 	}
 
@@ -22,7 +22,7 @@ suite('HTML Parser', () => {
 		assert.deepEqual(document.roots.map(toJSON), expected);
 	}
 
-	function assertNodeBefore(input: string, offset: number, expectedTag: string) {
+	function assertNodeBefore(input: string, offset: number, expectedTag: string | undefined) {
 		let document = parse(input);
 		let node = document.findNodeBefore(offset);
 		assert.equal(node ? node.tag : '', expectedTag, "offset " + offset);

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -9,6 +9,7 @@
  		"outDir": "../lib",
 		"lib": [
 			"es5", "es2015.promise"
-		]
+		],
+		"strict": true
 	 }
 } 


### PR DESCRIPTION
Enables strict mode compilation. Fixes:

* Annotate cases where params or return values can be null or undefined
* Add some missing null checks

Fixes #13