### PR TITLE
feat: add cursor positions for data attributes

### DIFF
--- a/src/services/htmlCompletion.ts
+++ b/src/services/htmlCompletion.ts
@@ -186,7 +186,7 @@ export function doComplete(document: TextDocument, position: Position, htmlDocum
 
 		function addNodeDataAttributes(node: Node) {
 			node.attributeNames.forEach(attr => {
-				if (startsWith(attr, dataAttr) && !dataAttributes[attr]) {
+				if (attr !== dataAttr && startsWith(attr, dataAttr) && !dataAttributes[attr]) {
 					dataAttributes[attr] = true;
 				}
 			});
@@ -196,7 +196,7 @@ export function doComplete(document: TextDocument, position: Position, htmlDocum
 		result.items.push({
 			label: dataAttr,
 			kind: CompletionItemKind.Value,
-			textEdit: TextEdit.replace(range, dataAttr),
+			textEdit: TextEdit.replace(range, `${dataAttr}$1="$2"`),
 			insertTextFormat: InsertTextFormat.Snippet
 		});
 		if (htmlDocument) {
@@ -204,7 +204,7 @@ export function doComplete(document: TextDocument, position: Position, htmlDocum
 			Object.keys(dataAttributes).forEach(attr => result.items.push({
 				label: attr,
 				kind: CompletionItemKind.Value,
-				textEdit: TextEdit.replace(range, attr + '=""'),
+				textEdit: TextEdit.replace(range, attr + '="$1"'),
 				insertTextFormat: InsertTextFormat.Snippet
 			}));
 		}

--- a/src/services/htmlCompletion.ts
+++ b/src/services/htmlCompletion.ts
@@ -182,32 +182,28 @@ export function doComplete(document: TextDocument, position: Position, htmlDocum
 	function collectDataAttributesSuggestions(range: Range) {
 
 		const dataAttr = 'data-';
-		let dataAttributes: { [name: string]: boolean } = {};
+		let dataAttributes: { [name: string]: string } = {};
+
+		dataAttributes[dataAttr] = `${dataAttr}$1="$2"`;
 
 		function addNodeDataAttributes(node: Node) {
 			node.attributeNames.forEach(attr => {
-				if (attr !== dataAttr && startsWith(attr, dataAttr) && !dataAttributes[attr]) {
-					dataAttributes[attr] = true;
+				if (startsWith(attr, dataAttr) && !dataAttributes[attr]) {
+					dataAttributes[attr] = attr + '="$1"';
 				}
 			});
 			node.children.forEach(child => addNodeDataAttributes(child));
 		}
 
-		result.items.push({
-			label: dataAttr,
-			kind: CompletionItemKind.Value,
-			textEdit: TextEdit.replace(range, `${dataAttr}$1="$2"`),
-			insertTextFormat: InsertTextFormat.Snippet
-		});
 		if (htmlDocument) {
 			htmlDocument.roots.forEach(root => addNodeDataAttributes(root));
-			Object.keys(dataAttributes).forEach(attr => result.items.push({
-				label: attr,
-				kind: CompletionItemKind.Value,
-				textEdit: TextEdit.replace(range, attr + '="$1"'),
-				insertTextFormat: InsertTextFormat.Snippet
-			}));
 		}
+		Object.keys(dataAttributes).forEach(attr => result.items.push({
+			label: attr,
+			kind: CompletionItemKind.Value,
+			textEdit: TextEdit.replace(range, dataAttributes[attr]),
+			insertTextFormat: InsertTextFormat.Snippet
+		}));
 	}
 
 	function collectAttributeValueSuggestions(valueStart: number, valueEnd: number = offset): CompletionList {

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -373,7 +373,7 @@ suite('HTML Completion', () => {
 			}, { hideAutoCompleteProposals: true }),
 			testCompletionFor('<div d|', {
 				items: [
-					{ label: 'data-', resultText: '<div data-' }
+					{ label: 'data-', resultText: '<div data-$1="$2"' }
 				]
 			}),
 			testCompletionFor('<div no-data-test="no-data" d|', {
@@ -383,15 +383,15 @@ suite('HTML Completion', () => {
 			}),
 			testCompletionFor('<div data-custom="test"><div d|', {
 				items: [
-					{ label: 'data-', resultText: '<div data-custom="test"><div data-' },
-					{ label: 'data-custom', resultText: '<div data-custom="test"><div data-custom=""' }
+					{ label: 'data-', resultText: '<div data-custom="test"><div data-$1="$2"' },
+					{ label: 'data-custom', resultText: '<div data-custom="test"><div data-custom="$1"' }
 				]
 			}),
 			testCompletionFor('<div data-custom="test"><div data-custom-two="2"></div></div>\n <div d|', {
 				items: [
-					{ label: 'data-', resultText: '<div data-custom="test"><div data-custom-two="2"></div></div>\n <div data-' },
-					{ label: 'data-custom', resultText: '<div data-custom="test"><div data-custom-two="2"></div></div>\n <div data-custom=""' },
-					{ label: 'data-custom-two', resultText: '<div data-custom="test"><div data-custom-two="2"></div></div>\n <div data-custom-two=""' }	
+					{ label: 'data-', resultText: '<div data-custom="test"><div data-custom-two="2"></div></div>\n <div data-$1="$2"' },
+					{ label: 'data-custom', resultText: '<div data-custom="test"><div data-custom-two="2"></div></div>\n <div data-custom="$1"' },
+					{ label: 'data-custom-two', resultText: '<div data-custom="test"><div data-custom-two="2"></div></div>\n <div data-custom-two="$1"' }	
 				]
 			})
 		], testDone);


### PR DESCRIPTION
Add cursor positions for data attributes
Also, add additional check so that data- appears only once in suggestions

Taking into account the observations made by @usernamehw in https://github.com/Microsoft/vscode/issues/40149