### PR TITLE
Emmet integration in html language service

### DIFF
--- a/src/htmlLanguageService.ts
+++ b/src/htmlLanguageService.ts
@@ -108,7 +108,7 @@ export interface DocumentContext {
 }
 
 export interface LanguageService {
-	createScanner(input: string): Scanner;
+	createScanner(input: string, initialOffset?: number): Scanner;
 	parseHTMLDocument(document: TextDocument): HTMLDocument;
 	findDocumentHighlights(document: TextDocument, position: Position, htmlDocument: HTMLDocument): DocumentHighlight[];
 	doComplete(document: TextDocument, position: Position, htmlDocument: HTMLDocument, options?: CompletionConfiguration): CompletionList;


### PR DESCRIPTION
Emmet completions in html are only for tags and not attributes. 

This PR adds another callback in the tag providers which will be used by emmet from the html extension in vscode.

Edit: As per https://github.com/Microsoft/vscode-html-languageservice/pull/19#issuecomment-358272255, the whole logic of deciding when to call emmet can be moved to the html extension in VSCode.

Only thing remaining is to expose the `initialOffset` param of the `createScanner` function
