### PR TITLE
Make it can be compressed by uglify-js

### DIFF
--- a/src/beautify/esm/beautify-css.js
+++ b/src/beautify/esm/beautify-css.js
@@ -1638,4 +1638,4 @@ module.exports.Options = Options;
 /***/ })
 /******/ ]);
 
-export const css_beautify = legacy_beautify_css;
+export var css_beautify = legacy_beautify_css;


### PR DESCRIPTION
The file `src/beautify/esm/beautify-css.js` has es6 syntax `const`, and it can't be compressed by uglify-js.