### PR TITLE
Add doNotAddAttributeQuotes setting to disable automatic quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+4.1.0 / 2021-09-27
+==================
+  * New settings `CompletionConfiguration.attributeDefaultValue`. Defines how attribute values are completed: With single or double quotes, or no quotes.
+
+
 4.0.0 / 2020-12-14
 ==================
   * Update to `vscode-languageserver-types@3.16`

--- a/src/htmlLanguageTypes.ts
+++ b/src/htmlLanguageTypes.ts
@@ -57,6 +57,7 @@ export interface HoverSettings {
 export interface CompletionConfiguration {
 	[provider: string]: boolean | undefined;
 	hideAutoCompleteProposals?: boolean;
+	doNotAddAttributeQuotes?: boolean;
 }
 
 export interface Node {

--- a/src/htmlLanguageTypes.ts
+++ b/src/htmlLanguageTypes.ts
@@ -57,7 +57,8 @@ export interface HoverSettings {
 export interface CompletionConfiguration {
 	[provider: string]: boolean | undefined;
 	hideAutoCompleteProposals?: boolean;
-	doNotAddAttributeQuotes?: boolean;
+	useEmptyAttrValue?: boolean;
+	useSingleQuotesForAttrs?: boolean;
 }
 
 export interface Node {

--- a/src/htmlLanguageTypes.ts
+++ b/src/htmlLanguageTypes.ts
@@ -55,10 +55,9 @@ export interface HoverSettings {
 }
 
 export interface CompletionConfiguration {
-	[provider: string]: boolean | undefined;
+	[provider: string]: boolean | undefined | string;
 	hideAutoCompleteProposals?: boolean;
-	useEmptyAttrValue?: boolean;
-	useSingleQuotesForAttrs?: boolean;
+	attributeDefaultValue?: 'empty' | 'singlequotes' | 'doublequotes';
 }
 
 export interface Node {

--- a/src/services/htmlCompletion.ts
+++ b/src/services/htmlCompletion.ts
@@ -204,7 +204,10 @@ export class HTMLCompletion {
 			}
 			const currentAttribute = text.substring(nameStart, nameEnd);
 			const range = getReplaceRange(nameStart, replaceEnd);
-			const value = isFollowedBy(text, nameEnd, ScannerState.AfterAttributeName, TokenType.DelimiterAssign) ? '' : '="$1"';
+			let value = '';
+			if (!isFollowedBy(text, nameEnd, ScannerState.AfterAttributeName, TokenType.DelimiterAssign)) {
+				value = (settings && settings.doNotAddAttributeQuotes) ? '=$1' : '="$1"';
+			}
 
 			const seenAttributes = getExistingAttributes();
 			// include current typing attribute

--- a/src/services/htmlCompletion.ts
+++ b/src/services/htmlCompletion.ts
@@ -206,9 +206,10 @@ export class HTMLCompletion {
 			const range = getReplaceRange(nameStart, replaceEnd);
 			let value = '';
 			if (!isFollowedBy(text, nameEnd, ScannerState.AfterAttributeName, TokenType.DelimiterAssign)) {
-				if (settings?.useEmptyAttrValue) {
+				const defaultValue = settings?.attributeDefaultValue ?? 'doublequotes';
+				if (defaultValue === 'empty') {
 					value = '=$1';
-				} else if (settings?.useSingleQuotesForAttrs) {
+				} else if (defaultValue === 'singlequotes') {
 					value = '=\'$1\'';
 				} else {
 					value = '="$1"';

--- a/src/services/htmlCompletion.ts
+++ b/src/services/htmlCompletion.ts
@@ -206,7 +206,13 @@ export class HTMLCompletion {
 			const range = getReplaceRange(nameStart, replaceEnd);
 			let value = '';
 			if (!isFollowedBy(text, nameEnd, ScannerState.AfterAttributeName, TokenType.DelimiterAssign)) {
-				value = (settings && settings.doNotAddAttributeQuotes) ? '=$1' : '="$1"';
+				if (settings?.useEmptyAttrValue) {
+					value = '=$1';
+				} else if (settings?.useSingleQuotesForAttrs) {
+					value = '=\'$1\'';
+				} else {
+					value = '="$1"';
+				}
 			}
 
 			const seenAttributes = getExistingAttributes();

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -410,14 +410,21 @@ suite('HTML Completion', () => {
 			{
 				items: [{ label: 'class', resultText: '<div class="$1"' }]
 			},
-			{ doNotAddAttributeQuotes: false }
+			{ useEmptyAttrValue: false }
+		);
+		testCompletionFor(
+			'<div clas|',
+			{
+				items: [{ label: 'class', resultText: '<div class=\'$1\'' }]
+			},
+			{ useSingleQuotesForAttrs: true }
 		);
 		testCompletionFor(
 			'<div clas|',
 			{
 				items: [{ label: 'class', resultText: '<div class=$1' }]
 			},
-			{ doNotAddAttributeQuotes: true }
+			{ useEmptyAttrValue: true }
 		);
 	});
 

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -410,21 +410,21 @@ suite('HTML Completion', () => {
 			{
 				items: [{ label: 'class', resultText: '<div class="$1"' }]
 			},
-			{ useEmptyAttrValue: false }
+			{ attributeDefaultValue: 'doublequotes' }
 		);
 		testCompletionFor(
 			'<div clas|',
 			{
 				items: [{ label: 'class', resultText: '<div class=\'$1\'' }]
 			},
-			{ useSingleQuotesForAttrs: true }
+			{ attributeDefaultValue: 'singlequotes' }
 		);
 		testCompletionFor(
 			'<div clas|',
 			{
 				items: [{ label: 'class', resultText: '<div class=$1' }]
 			},
-			{ useEmptyAttrValue: true }
+			{ attributeDefaultValue: 'empty' }
 		);
 	});
 

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -405,6 +405,20 @@ suite('HTML Completion', () => {
 			},
 			{ html5: false }
 		);
+		testCompletionFor(
+			'<div clas|',
+			{
+				items: [{ label: 'class', resultText: '<div class="$1"' }]
+			},
+			{ doNotAddAttributeQuotes: false }
+		);
+		testCompletionFor(
+			'<div clas|',
+			{
+				items: [{ label: 'class', resultText: '<div class=$1' }]
+			},
+			{ doNotAddAttributeQuotes: true }
+		);
 	});
 
 	test('doTagComplete', function (): any {


### PR DESCRIPTION
- For example, `clas|` completion will be `class=|` instead of `class="|"`