### PR TITLE
Trigger completion in all src and href attributes

### DIFF
--- a/src/services/pathCompletion.ts
+++ b/src/services/pathCompletion.ts
@@ -79,6 +79,9 @@ function isCompletablePath(value: string) {
 }
 
 function isPathAttribute(tag: string, attr: string) {
+	if (attr === 'src' || attr === 'href') {
+		return true;
+	}
 	const a = PATH_TAG_AND_ATTR[tag];
 	if (a) {
 		if (typeof a === 'string') {

--- a/src/test/pathCompletions.test.ts
+++ b/src/test/pathCompletions.test.ts
@@ -272,4 +272,21 @@ suite('HTML Path Completion', () => {
 		}, testUri);
 		*/
 	});
+
+	test('Trigger completion in src and href attributes of custom elements', async () => {
+		await testCompletion2For('<my-custom-element src="../|">', {
+			items: [
+				{ label: 'about/', resultText: '<my-custom-element src="../about/">' },
+				{ label: 'index.html', resultText: '<my-custom-element src="../index.html">' },
+				{ label: 'src/', resultText: '<my-custom-element src="../src/">' }
+			]
+		}, aboutHtmlUri);
+
+		await testCompletion2For('<my-custom-element href="../src/|">', {
+			items: [
+				{ label: 'feature.js', resultText: '<my-custom-element href="../src/feature.js">' },
+				{ label: 'test.js', resultText: '<my-custom-element href="../src/test.js">' },
+			]
+		}, aboutHtmlUri);
+	});
 });


### PR DESCRIPTION
This PR addresses #101 

I went with a slightly different approach than the two suggestions I outlined in the issue.

I decided not to alter the existing logic, which is enabling it in specific attributes where it makes sense by the HTML spec as laid out in the `PATH_TAG_AND_ATTR` object (referring to this stackoverflow comment: https://stackoverflow.com/questions/2725156/complete-list-of-html-tag-attributes-which-have-a-url-value/2725168#2725168).

Instead, I added a check before that, such that `isPathAttribute` will return `true` whenever the name of the attribute is `src` or `href`. 

I could have cleaned up the `PATH_TAG_AND_ATTR` object, as the `href` attribute on the `a` tag is already covered by the early return, but I kept it in there for completeness sake.

I added a test which shows that the completion is now triggered in both `href` and `src` attributes on a fictitious custom element.