### PR TITLE
fix: avoid using standard output

### DIFF
--- a/src/parser/htmlScanner.ts
+++ b/src/parser/htmlScanner.ts
@@ -191,7 +191,7 @@ export function createScanner(input: string, initialOffset = 0, initialState: Sc
 		const oldState = state;
 		const token = internalScan();
 		if (token !== TokenType.EOS && offset === stream.pos() && !(emitPseudoCloseTags && (token ===  TokenType.StartTagClose || token === TokenType.EndTagClose))) {
-			console.log('Scanner.scan has not advanced at offset ' + offset + ', state before: ' + oldState + ' after: ' + state);
+			console.warn('Scanner.scan has not advanced at offset ' + offset + ', state before: ' + oldState + ' after: ' + state);
 			stream.advance(1);
 			return finishToken(offset, TokenType.Unknown);
 		}


### PR DESCRIPTION
Logging to standard output breaks the protocol for language servers using stdio.
Eg. [@volar/vue-language-server](https://www.npmjs.com/package/@volar/vue-language-server) with [vscode-jsonrpc](https://www.npmjs.com/package/vscode-jsonrpc) breaks when typing
```jsx
<input label= />
```