### PR TITLE
Implement `findDocumentSymbols2()`

### DIFF
--- a/src/htmlLanguageService.ts
+++ b/src/htmlLanguageService.ts
@@ -10,14 +10,14 @@ import { HTMLHover } from './services/htmlHover';
 import { format } from './services/htmlFormatter';
 import { findDocumentLinks } from './services/htmlLinks';
 import { findDocumentHighlights } from './services/htmlHighlighting';
-import { findDocumentSymbols } from './services/htmlSymbolsProvider';
+import { findDocumentSymbols, findDocumentSymbols2 } from './services/htmlSymbolsProvider';
 import { doRename } from './services/htmlRename';
 import { findMatchingTagPosition } from './services/htmlMatchingTagPosition';
 import { findLinkedEditingRanges } from './services/htmlLinkedEditing';
 import {
-	Scanner, HTMLDocument, CompletionConfiguration, ICompletionParticipant, HTMLFormatConfiguration, DocumentContext,
+	Scanner, HTMLDocument, CompletionConfiguration, ICompletionParticipant, HTMLFormatConfiguration, DocumentContext, DocumentSymbol,
 	IHTMLDataProvider, HTMLDataV1, LanguageServiceOptions, TextDocument, SelectionRange, WorkspaceEdit,
-	Position, CompletionList, Hover, Range, SymbolInformation, TextEdit, DocumentHighlight, DocumentLink, FoldingRange, HoverSettings
+	Position, CompletionList, Hover, Range, SymbolInformation, TextEdit, DocumentHighlight, DocumentLink, FoldingRange, HoverSettings,
 } from './htmlLanguageTypes';
 import { HTMLFolding } from './services/htmlFolding';
 import { HTMLSelectionRange } from './services/htmlSelectionRange';
@@ -39,6 +39,7 @@ export interface LanguageService {
 	format(document: TextDocument, range: Range | undefined, options: HTMLFormatConfiguration): TextEdit[];
 	findDocumentLinks(document: TextDocument, documentContext: DocumentContext): DocumentLink[];
 	findDocumentSymbols(document: TextDocument, htmlDocument: HTMLDocument): SymbolInformation[];
+	findDocumentSymbols2(document: TextDocument, htmlDocument: HTMLDocument): DocumentSymbol[];
 	doQuoteComplete(document: TextDocument, position: Position, htmlDocument: HTMLDocument, options?: CompletionConfiguration): string | null;
 	doTagComplete(document: TextDocument, position: Position, htmlDocument: HTMLDocument): string | null;
 	getFoldingRanges(document: TextDocument, context?: { rangeLimit?: number }): FoldingRange[];
@@ -73,6 +74,7 @@ export function getLanguageService(options: LanguageServiceOptions = defaultLang
 		findDocumentHighlights,
 		findDocumentLinks,
 		findDocumentSymbols,
+		findDocumentSymbols2,
 		getFoldingRanges: htmlFolding.getFoldingRanges.bind(htmlFolding),
 		getSelectionRanges: htmlSelectionRange.getSelectionRanges.bind(htmlSelectionRange),
 		doQuoteComplete: htmlCompletion.doQuoteComplete.bind(htmlCompletion),

--- a/src/htmlLanguageTypes.ts
+++ b/src/htmlLanguageTypes.ts
@@ -8,7 +8,7 @@ import {
 	MarkupContent, MarkupKind, MarkedString, DocumentUri,
 	SelectionRange, WorkspaceEdit,
 	CompletionList, CompletionItemKind, CompletionItem, CompletionItemTag, InsertTextMode, Command,
-	SymbolInformation, SymbolKind,
+	SymbolInformation, DocumentSymbol, SymbolKind,
 	Hover, TextEdit, InsertReplaceEdit, InsertTextFormat, DocumentHighlight, DocumentHighlightKind,
 	DocumentLink, FoldingRange, FoldingRangeKind,
 	SignatureHelp, Definition, Diagnostic, FormattingOptions, Color, ColorInformation, ColorPresentation
@@ -22,7 +22,7 @@ export {
 	MarkupContent, MarkupKind, MarkedString, DocumentUri,
 	SelectionRange, WorkspaceEdit,
 	CompletionList, CompletionItemKind, CompletionItem, CompletionItemTag, InsertTextMode, Command,
-	SymbolInformation, SymbolKind,
+	SymbolInformation, DocumentSymbol, SymbolKind,
 	Hover, TextEdit, InsertReplaceEdit, InsertTextFormat, DocumentHighlight, DocumentHighlightKind,
 	DocumentLink, FoldingRange, FoldingRangeKind,
 	SignatureHelp, Definition, Diagnostic, FormattingOptions, Color, ColorInformation, ColorPresentation

--- a/src/test/symbols.test.ts
+++ b/src/test/symbols.test.ts
@@ -6,56 +6,90 @@
 import * as assert from 'assert';
 import * as htmlLanguageService from '../htmlLanguageService';
 
-import { SymbolInformation, SymbolKind, Location, Range, TextDocument } from '../htmlLanguageService';
+import { SymbolInformation, SymbolKind, Location, Range, TextDocument, DocumentSymbol } from '../htmlLanguageService';
 
 suite('HTML Symbols', () => {
 
 	const TEST_URI = "test://test/test.html";
 
-	function asPromise<T>(result: T): Promise<T> {
-		return Promise.resolve(result);
-	}
-
-	const assertSymbols = function (symbols: SymbolInformation[], expected: SymbolInformation[]) {
-		assert.deepEqual(symbols, expected);
-	};
-
-	const testSymbolsFor = function (value: string, expected: SymbolInformation[]) {
+	const testSymbolInformationsFor = function (value: string, expected: SymbolInformation[]) {
 		const ls = htmlLanguageService.getLanguageService();
 		const document = TextDocument.create(TEST_URI, 'html', 0, value);
 		const htmlDoc = ls.parseHTMLDocument(document);
 		const symbols = ls.findDocumentSymbols(document, htmlDoc);
-		assertSymbols(symbols, expected);
+		assert.deepEqual(symbols, expected);
+	};
+
+	const testDocumentSymbolsFor = function (value: string, expected: DocumentSymbol[]) {
+		const ls = htmlLanguageService.getLanguageService();
+		const document = TextDocument.create(TEST_URI, 'html', 0, value);
+		const htmlDoc = ls.parseHTMLDocument(document);
+		const symbols = ls.findDocumentSymbols2(document, htmlDoc);
+		assert.deepEqual(symbols, expected);
 	};
 
 	test('Simple', () => {
-		testSymbolsFor('<div></div>', [<SymbolInformation>{ containerName: '', name: 'div', kind: <SymbolKind>SymbolKind.Field, location: Location.create(TEST_URI, Range.create(0, 0, 0, 11)) }]);
-		testSymbolsFor('<div><input checked id="test" class="checkbox"></div>', [{ containerName: '', name: 'div', kind: <SymbolKind>SymbolKind.Field, location: Location.create(TEST_URI, Range.create(0, 0, 0, 53)) },
-		{ containerName: 'div', name: 'input#test.checkbox', kind: <SymbolKind>SymbolKind.Field, location: Location.create(TEST_URI, Range.create(0, 5, 0, 47)) }]);
+		testSymbolInformationsFor('<div></div>', [
+			{ containerName: '', name: 'div', kind: <SymbolKind>SymbolKind.Field, location: Location.create(TEST_URI, Range.create(0, 0, 0, 11)) }
+		]);
+		testSymbolInformationsFor('<div><input checked id="test" class="checkbox"></div>',
+			[
+				{ containerName: '', name: 'div', kind: <SymbolKind>SymbolKind.Field, location: Location.create(TEST_URI, Range.create(0, 0, 0, 53)) },
+				{ containerName: 'div', name: 'input#test.checkbox', kind: <SymbolKind>SymbolKind.Field, location: Location.create(TEST_URI, Range.create(0, 5, 0, 47)) }
+			]
+		);
+
+		testDocumentSymbolsFor('<div></div>', [
+			DocumentSymbol.create('div', undefined, SymbolKind.Field, Range.create(0, 0, 0, 11), Range.create(0, 0, 0, 11))
+		]);
+		testDocumentSymbolsFor('<div><input checked id="test" class="checkbox"></div>',
+			[
+				DocumentSymbol.create('div', undefined, SymbolKind.Field, Range.create(0, 0, 0, 53), Range.create(0, 0, 0, 53), [
+					DocumentSymbol.create('input#test.checkbox', undefined, SymbolKind.Field, Range.create(0, 5, 0, 47), Range.create(0, 5, 0, 47))
+				])
+			]
+		);
 	});
 
 	test('Id and classes', function () {
 		const content = '<html id=\'root\'><body id="Foo" class="bar"><div class="a b"></div></body></html>';
 
-		const expected = [
+		const expected1 = [
 			{ name: 'html#root', kind: SymbolKind.Field, containerName: '', location: Location.create(TEST_URI, Range.create(0, 0, 0, 80)) },
 			{ name: 'body#Foo.bar', kind: SymbolKind.Field, containerName: 'html#root', location: Location.create(TEST_URI, Range.create(0, 16, 0, 73)) },
 			{ name: 'div.a.b', kind: SymbolKind.Field, containerName: 'body#Foo.bar', location: Location.create(TEST_URI, Range.create(0, 43, 0, 66)) },
 		];
 
-		testSymbolsFor(content, expected);
+		testSymbolInformationsFor(content, expected1);
+
+		const expected2: DocumentSymbol[] = [
+			DocumentSymbol.create("html#root", undefined, SymbolKind.Field, Range.create(0, 0, 0, 80), Range.create(0, 0, 0, 80), [
+				DocumentSymbol.create("body#Foo.bar", undefined, SymbolKind.Field, Range.create(0, 16, 0, 73), Range.create(0, 16, 0, 73), [
+					DocumentSymbol.create("div.a.b", undefined, SymbolKind.Field, Range.create(0, 43, 0, 66), Range.create(0, 43, 0, 66))
+				])
+			])
+		];
+		testDocumentSymbolsFor(content, expected2);
 	});
 
 	test('Self closing', function () {
 		const content = '<html><br id="Foo"><br id=Bar></html>';
 
-		const expected = [
+		const expected1 = [
 			{ name: 'html', kind: SymbolKind.Field, containerName: '', location: Location.create(TEST_URI, Range.create(0, 0, 0, 37)) },
 			{ name: 'br#Foo', kind: SymbolKind.Field, containerName: 'html', location: Location.create(TEST_URI, Range.create(0, 6, 0, 19)) },
 			{ name: 'br#Bar', kind: SymbolKind.Field, containerName: 'html', location: Location.create(TEST_URI, Range.create(0, 19, 0, 30)) },
 		];
 
-		testSymbolsFor(content, expected);
+		testSymbolInformationsFor(content, expected1);
+
+		const expected2: DocumentSymbol[] = [
+			DocumentSymbol.create("html", undefined, SymbolKind.Field, Range.create(0, 0, 0, 37), Range.create(0, 0, 0, 37), [
+				DocumentSymbol.create("br#Foo", undefined, SymbolKind.Field, Range.create(0, 6, 0, 19), Range.create(0, 6, 0, 19)),
+				DocumentSymbol.create("br#Bar", undefined, SymbolKind.Field, Range.create(0, 19, 0, 30), Range.create(0, 19, 0, 30))
+			])
+		];
+		testDocumentSymbolsFor(content, expected2);
 	});
 
 	test('No attrib', function () {
@@ -67,6 +101,15 @@ suite('HTML Symbols', () => {
 			{ name: 'div', kind: SymbolKind.Field, containerName: 'body', location: Location.create(TEST_URI, Range.create(0, 12, 0, 23)) }
 		];
 
-		testSymbolsFor(content, expected);
+		testSymbolInformationsFor(content, expected);
+
+		const expected2: DocumentSymbol[] = [
+			DocumentSymbol.create("html", undefined, SymbolKind.Field, Range.create(0, 0, 0, 37), Range.create(0, 0, 0, 37), [
+				DocumentSymbol.create("body", undefined, SymbolKind.Field, Range.create(0, 6, 0, 30), Range.create(0, 6, 0, 30), [
+					DocumentSymbol.create("div", undefined, SymbolKind.Field, Range.create(0, 12, 0, 23), Range.create(0, 12, 0, 23))
+				])
+			])
+		];
+		testDocumentSymbolsFor(content, expected2);
 	});
 });


### PR DESCRIPTION
Look to https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol, `DocumentSymbol` is a better data structure. Added `findDocumentSymbols2()` API to return `DocumentSymbol[]` and align with `vscode-css-languageservice` and `vscode-json-languageservice`.

Fix #130.