### PR TITLE
feat: make `IHTMLDataProvider` async

### DIFF
--- a/src/htmlLanguageService.ts
+++ b/src/htmlLanguageService.ts
@@ -30,20 +30,20 @@ export * from './htmlLanguageTypes';
 export interface LanguageService {
 	setDataProviders(useDefaultDataProvider: boolean, customDataProviders: IHTMLDataProvider[]): void;
 	createScanner(input: string, initialOffset?: number): Scanner;
-	parseHTMLDocument(document: TextDocument): HTMLDocument;
+	parseHTMLDocument(document: TextDocument): Promise<HTMLDocument>;
 	findDocumentHighlights(document: TextDocument, position: Position, htmlDocument: HTMLDocument): DocumentHighlight[];
-	doComplete(document: TextDocument, position: Position, htmlDocument: HTMLDocument, options?: CompletionConfiguration): CompletionList;
+	doComplete(document: TextDocument, position: Position, htmlDocument: HTMLDocument, options?: CompletionConfiguration): Promise<CompletionList>;
 	doComplete2(document: TextDocument, position: Position, htmlDocument: HTMLDocument, documentContext: DocumentContext, options?: CompletionConfiguration): Promise<CompletionList>;
 	setCompletionParticipants(registeredCompletionParticipants: ICompletionParticipant[]): void;
-	doHover(document: TextDocument, position: Position, htmlDocument: HTMLDocument, options?: HoverSettings): Hover | null;
+	doHover(document: TextDocument, position: Position, htmlDocument: HTMLDocument, options?: HoverSettings): Promise<Hover | null>;
 	format(document: TextDocument, range: Range | undefined, options: HTMLFormatConfiguration): TextEdit[];
 	findDocumentLinks(document: TextDocument, documentContext: DocumentContext): DocumentLink[];
 	findDocumentSymbols(document: TextDocument, htmlDocument: HTMLDocument): SymbolInformation[];
 	findDocumentSymbols2(document: TextDocument, htmlDocument: HTMLDocument): DocumentSymbol[];
 	doQuoteComplete(document: TextDocument, position: Position, htmlDocument: HTMLDocument, options?: CompletionConfiguration): string | null;
-	doTagComplete(document: TextDocument, position: Position, htmlDocument: HTMLDocument): string | null;
-	getFoldingRanges(document: TextDocument, context?: { rangeLimit?: number }): FoldingRange[];
-	getSelectionRanges(document: TextDocument, positions: Position[]): SelectionRange[];
+	doTagComplete(document: TextDocument, position: Position, htmlDocument: HTMLDocument): Promise<string | null>;
+	getFoldingRanges(document: TextDocument, context?: { rangeLimit?: number }): Promise<FoldingRange[]>;
+	getSelectionRanges(document: TextDocument, positions: Position[]): Promise<SelectionRange[]>;
 	doRename(document: TextDocument, position: Position, newName: string, htmlDocument: HTMLDocument): WorkspaceEdit | null;
 	findMatchingTagPosition(document: TextDocument, position: Position, htmlDocument: HTMLDocument): Position | null;
 	/** Deprecated, Use findLinkedEditingRanges instead */

--- a/src/htmlLanguageTypes.ts
+++ b/src/htmlLanguageTypes.ts
@@ -193,9 +193,9 @@ export interface IHTMLDataProvider {
 	getId(): string;
 	isApplicable(languageId: string): boolean;
 
-	provideTags(): ITagData[];
-	provideAttributes(tag: string): IAttributeData[];
-	provideValues(tag: string, attribute: string): IValueData[];
+	provideTags(): Promise<ITagData[]> | ITagData[];
+	provideAttributes(tag: string): Promise<IAttributeData[]> | IAttributeData[];
+	provideValues(tag: string, attribute: string): Promise<IValueData[]> | IValueData[];
 }
 
 /**

--- a/src/languageFacts/dataManager.ts
+++ b/src/languageFacts/dataManager.ts
@@ -30,14 +30,15 @@ export class HTMLDataManager {
 		return !!e && arrays.binarySearch(voidElements, e.toLowerCase(), (s1: string, s2: string) => s1.localeCompare(s2)) >= 0;
 	}
 
-	getVoidElements(languageId: string): string[];
-	getVoidElements(dataProviders: IHTMLDataProvider[]): string[];
-	getVoidElements(languageOrProviders: string | IHTMLDataProvider[]): string[] {
+	getVoidElements(languageId: string): Promise<string[]>;
+	getVoidElements(dataProviders: IHTMLDataProvider[]): Promise<string[]>;
+	async getVoidElements(languageOrProviders: string | IHTMLDataProvider[]): Promise<string[]> {
 		const dataProviders = Array.isArray(languageOrProviders) ? languageOrProviders : this.getDataProviders().filter(p => p.isApplicable(languageOrProviders!));
 		const voidTags: string[] = [];
-		dataProviders.forEach((provider) => {
-			provider.provideTags().filter(tag => tag.void).forEach(tag => voidTags.push(tag.name));
-		});
+		for (const provider of dataProviders) {
+			const tags = await provider.provideTags();
+			tags.filter(tag => tag.void).forEach(tag => voidTags.push(tag.name));
+		}
 		return voidTags.sort();
 	}
 

--- a/src/parser/htmlParser.ts
+++ b/src/parser/htmlParser.ts
@@ -68,8 +68,8 @@ export class HTMLParser {
 
   }
 
-  public parseDocument(document: TextDocument): HTMLDocument {
-    return this.parse(document.getText(), this.dataManager.getVoidElements(document.languageId));
+  public async parseDocument(document: TextDocument): Promise<HTMLDocument> {
+    return this.parse(document.getText(), await this.dataManager.getVoidElements(document.languageId));
   }
 
   public parse(text: string, voidElements: string[]): HTMLDocument {

--- a/src/services/htmlFolding.ts
+++ b/src/services/htmlFolding.ts
@@ -83,7 +83,7 @@ export class HTMLFolding {
 		return result;
 	}
 
-	public getFoldingRanges(document: TextDocument, context: { rangeLimit?: number } | undefined): FoldingRange[] {
+	public async getFoldingRanges(document: TextDocument, context: { rangeLimit?: number } | undefined): Promise<FoldingRange[]> {
 		const scanner = createScanner(document.getText());
 		let token = scanner.scan();
 		const ranges: FoldingRange[] = [];
@@ -114,7 +114,7 @@ export class HTMLFolding {
 					if (!lastTagName) {
 						break;
 					}
-					voidElements ??= this.dataManager.getVoidElements(document.languageId);
+					voidElements ??= await this.dataManager.getVoidElements(document.languageId);
 					if (!this.dataManager.isVoidElement(lastTagName, voidElements)) {
 						break;
 					}

--- a/src/services/htmlSelectionRange.ts
+++ b/src/services/htmlSelectionRange.ts
@@ -12,8 +12,8 @@ export class HTMLSelectionRange {
 	constructor(private htmlParser: HTMLParser) {
 	}
 
-	public getSelectionRanges(document: TextDocument, positions: Position[]): SelectionRange[] {
-		const htmlDocument = this.htmlParser.parseDocument(document);
+	public async getSelectionRanges(document: TextDocument, positions: Position[]): Promise<SelectionRange[]> {
+		const htmlDocument = await this.htmlParser.parseDocument(document);
 		return positions.map(p => this.getSelectionRange(p, document, htmlDocument));
 	}
 	private getSelectionRange(position: Position, document: TextDocument, htmlDocument: HTMLDocument): SelectionRange {

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -6,8 +6,8 @@
 import { testCompletionFor, testQuoteCompletion, testTagCompletion } from "./completionUtil";
 
 suite('HTML Completion', () => {
-	test('Complete', function (): any {
-		testCompletionFor('<|', {
+	test('Complete', async () => {
+		await testCompletionFor('<|', {
 			items: [
 				{ label: '!DOCTYPE', resultText: '<!DOCTYPE html>' },
 				{ label: 'iframe', resultText: '<iframe' },
@@ -16,11 +16,11 @@ suite('HTML Completion', () => {
 			]
 		});
 
-		testCompletionFor('\n<|', {
+		await testCompletionFor('\n<|', {
 			items: [{ label: '!DOCTYPE', notAvailable: true }, { label: 'iframe' }, { label: 'h1' }, { label: 'div' }]
 		});
 
-		testCompletionFor('< |', {
+		await testCompletionFor('< |', {
 			items: [
 				{ label: 'iframe', resultText: '<iframe' },
 				{ label: 'h1', resultText: '<h1' },
@@ -28,7 +28,7 @@ suite('HTML Completion', () => {
 			]
 		});
 
-		testCompletionFor('<h|', {
+		await testCompletionFor('<h|', {
 			items: [
 				{ label: 'html', resultText: '<html' },
 				{ label: 'h1', resultText: '<h1' },
@@ -36,16 +36,16 @@ suite('HTML Completion', () => {
 			]
 		});
 
-		testCompletionFor('<input|', {
+		await testCompletionFor('<input|', {
 			items: [{ label: 'input', resultText: '<input' }]
 		});
-		testCompletionFor('<inp|ut', {
+		await testCompletionFor('<inp|ut', {
 			items: [{ label: 'input', resultText: '<input' }]
 		});
-		testCompletionFor('<|inp', {
+		await testCompletionFor('<|inp', {
 			items: [{ label: 'input', resultText: '<input' }]
 		});
-		testCompletionFor('<input |', {
+		await testCompletionFor('<input |', {
 			items: [
 				{ label: 'type', resultText: '<input type="$1"' },
 				{ label: 'style', resultText: '<input style="$1"' },
@@ -53,28 +53,28 @@ suite('HTML Completion', () => {
 			]
 		});
 
-		testCompletionFor('<input t|', {
+		await testCompletionFor('<input t|', {
 			items: [
 				{ label: 'type', resultText: '<input type="$1"' },
 				{ label: 'tabindex', resultText: '<input tabindex="$1"' }
 			]
 		});
 
-		testCompletionFor('<input t|ype', {
+		await testCompletionFor('<input t|ype', {
 			items: [
 				{ label: 'type', resultText: '<input type="$1"' },
 				{ label: 'tabindex', resultText: '<input tabindex="$1"' }
 			]
 		});
 
-		testCompletionFor('<input t|ype="text"', {
+		await testCompletionFor('<input t|ype="text"', {
 			items: [
 				{ label: 'type', resultText: '<input type="text"' },
 				{ label: 'tabindex', resultText: '<input tabindex="text"' }
 			]
 		});
 
-		testCompletionFor('<input type="text" |', {
+		await testCompletionFor('<input type="text" |', {
 			items: [
 				{ label: 'style', resultText: '<input type="text" style="$1"' },
 				{ label: 'type', notAvailable: true },
@@ -82,7 +82,7 @@ suite('HTML Completion', () => {
 			]
 		});
 
-		testCompletionFor('<input | type="text"', {
+		await testCompletionFor('<input | type="text"', {
 			items: [
 				{ label: 'style', resultText: '<input style="$1" type="text"' },
 				{ label: 'type', notAvailable: true },
@@ -90,7 +90,7 @@ suite('HTML Completion', () => {
 			]
 		});
 
-		testCompletionFor('<input type="text" type="number" |', {
+		await testCompletionFor('<input type="text" type="number" |', {
 			items: [
 				{ label: 'style', resultText: '<input type="text" type="number" style="$1"' },
 				{ label: 'type', notAvailable: true },
@@ -98,7 +98,7 @@ suite('HTML Completion', () => {
 			]
 		});
 
-		testCompletionFor('<input type="text" s|', {
+		await testCompletionFor('<input type="text" s|', {
 			items: [
 				{ label: 'style', resultText: '<input type="text" style="$1"' },
 				{ label: 'src', resultText: '<input type="text" src="$1"' },
@@ -106,114 +106,114 @@ suite('HTML Completion', () => {
 			]
 		});
 
-		testCompletionFor('<input di| type="text"', {
+		await testCompletionFor('<input di| type="text"', {
 			items: [
 				{ label: 'disabled', resultText: '<input disabled type="text"' },
 				{ label: 'dir', resultText: '<input dir="$1" type="text"' }
 			]
 		});
 
-		testCompletionFor('<input disabled | type="text"', {
+		await testCompletionFor('<input disabled | type="text"', {
 			items: [
 				{ label: 'dir', resultText: '<input disabled dir="$1" type="text"' },
 				{ label: 'style', resultText: '<input disabled style="$1" type="text"' }
 			]
 		});
 
-		testCompletionFor('<input type=|', {
+		await testCompletionFor('<input type=|', {
 			items: [
 				{ label: 'text', resultText: '<input type="text"' },
 				{ label: 'checkbox', resultText: '<input type="checkbox"' }
 			]
 		});
-		testCompletionFor('<input type="c|', {
+		await testCompletionFor('<input type="c|', {
 			items: [
 				{ label: 'color', resultText: '<input type="color' },
 				{ label: 'checkbox', resultText: '<input type="checkbox' }
 			]
 		});
-		testCompletionFor('<input type="|', {
+		await testCompletionFor('<input type="|', {
 			items: [
 				{ label: 'color', resultText: '<input type="color' },
 				{ label: 'checkbox', resultText: '<input type="checkbox' }
 			]
 		});
-		testCompletionFor('<input type= |', {
+		await testCompletionFor('<input type= |', {
 			items: [
 				{ label: 'color', resultText: '<input type= "color"' },
 				{ label: 'checkbox', resultText: '<input type= "checkbox"' }
 			]
 		});
-		testCompletionFor('<input src="c" type="color|" ', {
+		await testCompletionFor('<input src="c" type="color|" ', {
 			items: [{ label: 'color', resultText: '<input src="c" type="color" ' }]
 		});
-		testCompletionFor('<iframe sandbox="allow-forms |', {
+		await testCompletionFor('<iframe sandbox="allow-forms |', {
 			items: [{ label: 'allow-modals', resultText: '<iframe sandbox="allow-forms allow-modals' }]
 		});
-		testCompletionFor('<iframe sandbox="allow-forms allow-modals|', {
+		await testCompletionFor('<iframe sandbox="allow-forms allow-modals|', {
 			items: [{ label: 'allow-modals', resultText: '<iframe sandbox="allow-forms allow-modals' }]
 		});
-		testCompletionFor('<iframe sandbox="allow-forms all|"', {
+		await testCompletionFor('<iframe sandbox="allow-forms all|"', {
 			items: [{ label: 'allow-modals', resultText: '<iframe sandbox="allow-forms allow-modals"' }]
 		});
-		testCompletionFor('<iframe sandbox="allow-forms a|llow-modals "', {
+		await testCompletionFor('<iframe sandbox="allow-forms a|llow-modals "', {
 			items: [{ label: 'allow-modals', resultText: '<iframe sandbox="allow-forms allow-modals "' }]
 		});
-		testCompletionFor('<input src="c" type=color| ', {
+		await testCompletionFor('<input src="c" type=color| ', {
 			items: [{ label: 'color', resultText: '<input src="c" type="color" ' }]
 		});
-		testCompletionFor('<div dir=|></div>', {
+		await testCompletionFor('<div dir=|></div>', {
 			items: [
 				{ label: 'ltr', resultText: '<div dir="ltr"></div>' },
 				{ label: 'rtl', resultText: '<div dir="rtl"></div>' }
 			]
 		});
-		testCompletionFor('<ul><|>', {
+		await testCompletionFor('<ul><|>', {
 			items: [{ label: '/ul', resultText: '<ul></ul>' }, { label: 'li', resultText: '<ul><li>' }]
 		});
-		testCompletionFor('<ul><li><|', {
+		await testCompletionFor('<ul><li><|', {
 			items: [{ label: '/li', resultText: '<ul><li></li>' }, { label: 'a', resultText: '<ul><li><a' }]
 		});
-		testCompletionFor('<goo></|>', {
+		await testCompletionFor('<goo></|>', {
 			items: [{ label: '/goo', resultText: '<goo></goo>' }]
 		});
-		testCompletionFor('<foo></f|', {
+		await testCompletionFor('<foo></f|', {
 			items: [{ label: '/foo', resultText: '<foo></foo>' }]
 		});
-		testCompletionFor('<foo></f|o', {
+		await testCompletionFor('<foo></f|o', {
 			items: [{ label: '/foo', resultText: '<foo></foo>' }]
 		});
-		testCompletionFor('<foo></|fo', {
+		await testCompletionFor('<foo></|fo', {
 			items: [{ label: '/foo', resultText: '<foo></foo>' }]
 		});
-		testCompletionFor('<foo></ |>', {
+		await testCompletionFor('<foo></ |>', {
 			items: [{ label: '/foo', resultText: '<foo></foo>' }]
 		});
-		testCompletionFor('<span></ s|', {
+		await testCompletionFor('<span></ s|', {
 			items: [{ label: '/span', resultText: '<span></span>' }]
 		});
-		testCompletionFor('<li><br></ |>', {
+		await testCompletionFor('<li><br></ |>', {
 			items: [{ label: '/li', resultText: '<li><br></li>' }]
 		});
-		testCompletionFor('<li/|>', {
+		await testCompletionFor('<li/|>', {
 			count: 0
 		});
-		testCompletionFor('  <div/|   ', {
+		await testCompletionFor('  <div/|   ', {
 			count: 0
 		});
-		testCompletionFor('<foo><br/></ f|>', {
+		await testCompletionFor('<foo><br/></ f|>', {
 			items: [{ label: '/foo', resultText: '<foo><br/></foo>' }]
 		});
-		testCompletionFor('<li><div/></|', {
+		await testCompletionFor('<li><div/></|', {
 			items: [{ label: '/li', resultText: '<li><div/></li>' }]
 		});
-		testCompletionFor('<li><br/|>', { count: 0 });
-		testCompletionFor('<li><br>a/|', { count: 0 });
+		await testCompletionFor('<li><br/|>', { count: 0 });
+		await testCompletionFor('<li><br>a/|', { count: 0 });
 
-		testCompletionFor('<foo><bar></bar></|   ', {
+		await testCompletionFor('<foo><bar></bar></|   ', {
 			items: [{ label: '/foo', resultText: '<foo><bar></bar></foo>   ' }]
 		});
-		testCompletionFor('<div>\n  <form>\n    <div>\n      <label></label>\n      <|\n    </div>\n  </form></div>', {
+		await testCompletionFor('<div>\n  <form>\n    <div>\n      <label></label>\n      <|\n    </div>\n  </form></div>', {
 			items: [
 				{
 					label: 'span',
@@ -226,47 +226,47 @@ suite('HTML Completion', () => {
 				}
 			]
 		});
-		testCompletionFor('<body><div><div></div></div></|  >', {
+		await testCompletionFor('<body><div><div></div></div></|  >', {
 			items: [{ label: '/body', resultText: '<body><div><div></div></div></body  >' }]
 		});
-		testCompletionFor(['<body>', '  <div>', '    </|'].join('\n'), {
+		await testCompletionFor(['<body>', '  <div>', '    </|'].join('\n'), {
 			items: [{ label: '/div', resultText: ['<body>', '  <div>', '  </div>'].join('\n') }]
 		});
-		testCompletionFor('<div><a hre|</div>', {
+		await testCompletionFor('<div><a hre|</div>', {
 			items: [{ label: 'href', resultText: '<div><a href="$1"</div>' }]
 		});
-		testCompletionFor('<a><b>foo</b><|f>', {
+		await testCompletionFor('<a><b>foo</b><|f>', {
 			items: [{ label: '/a', resultText: '<a><b>foo</b></a>' }, { notAvailable: true, label: '/f' }]
 		});
-		testCompletionFor('<a><b>foo</b><| bar.', {
+		await testCompletionFor('<a><b>foo</b><| bar.', {
 			items: [{ label: '/a', resultText: '<a><b>foo</b></a> bar.' }, { notAvailable: true, label: '/bar' }]
 		});
-		testCompletionFor('<div><h1><br><span></span><img></| </h1></div>', {
+		await testCompletionFor('<div><h1><br><span></span><img></| </h1></div>', {
 			items: [{ label: '/h1', resultText: '<div><h1><br><span></span><img></h1> </h1></div>' }]
 		});
-		testCompletionFor('<div>|', {
+		await testCompletionFor('<div>|', {
 			items: [{ label: '</div>', resultText: '<div>$0</div>' }]
 		});
-		testCompletionFor(
+		await testCompletionFor(
 			'<div>|',
 			{
 				items: [{ notAvailable: true, label: '</div>' }]
 			},
 			{ hideAutoCompleteProposals: true }
 		);
-		testCompletionFor('<div d|', {
+		await testCompletionFor('<div d|', {
 			items: [{ label: 'data-', resultText: '<div data-$1="$2"' }]
 		});
-		testCompletionFor('<div no-data-test="no-data" d|', {
+		await testCompletionFor('<div no-data-test="no-data" d|', {
 			items: [{ notAvailable: true, label: 'no-data-test' }]
 		});
-		testCompletionFor('<div data-custom="test"><div d|', {
+		await testCompletionFor('<div data-custom="test"><div d|', {
 			items: [
 				{ label: 'data-', resultText: '<div data-custom="test"><div data-$1="$2"' },
 				{ label: 'data-custom', resultText: '<div data-custom="test"><div data-custom="$1"' }
 			]
 		});
-		testCompletionFor('<div data-custom="test"><div data-custom-two="2"></div></div>\n <div d|', {
+		await testCompletionFor('<div data-custom="test"><div data-custom-two="2"></div></div>\n <div d|', {
 			items: [
 				{
 					label: 'data-',
@@ -282,7 +282,7 @@ suite('HTML Completion', () => {
 				}
 			]
 		});
-		testCompletionFor(
+		await testCompletionFor(
 			`<body data-ng-app=""><div id="first" data-ng-include=" 'firstdoc.html' "></div><div id="second" inc|></div></body>`,
 			{
 				items: [
@@ -295,52 +295,52 @@ suite('HTML Completion', () => {
 		);
 	});
 
-	test('References', () => {
+	test('References', async () => {
 		const doc =
 			'The div element has no special meaning at all. It represents its children. It can be used with the class, lang, and title attributes to mark up semantics common to a group of consecutive elements.' +
 			'\n\n' +
 			'[MDN Reference](https://developer.mozilla.org/docs/Web/HTML/Element/div)';
 
-		testCompletionFor('<d|', {
+		await testCompletionFor('<d|', {
 			items: [{ label: 'div', resultText: '<div', documentation: { kind: 'markdown', value: doc } }]
 		});
 	});
 
-	test('Case sensitivity', function () {
-		testCompletionFor('<LI></|', {
+	test('Case sensitivity', async () => {
+		await testCompletionFor('<LI></|', {
 			items: [{ label: '/LI', resultText: '<LI></LI>' }, { label: '/li', notAvailable: true }]
 		});
-		testCompletionFor('<lI></|', {
+		await testCompletionFor('<lI></|', {
 			items: [{ label: '/lI', resultText: '<lI></lI>' }]
 		});
-		testCompletionFor('<iNpUt |', {
+		await testCompletionFor('<iNpUt |', {
 			items: [{ label: 'type', resultText: '<iNpUt type="$1"' }]
 		});
-		testCompletionFor('<INPUT TYPE=|', {
+		await testCompletionFor('<INPUT TYPE=|', {
 			items: [{ label: 'color', resultText: '<INPUT TYPE="color"' }]
 		});
-		testCompletionFor('<dIv>|', {
+		await testCompletionFor('<dIv>|', {
 			items: [{ label: '</dIv>', resultText: '<dIv>$0</dIv>' }]
 		});
 	});
 
-	test('Handlebar Completion', function () {
-		testCompletionFor('<script id="entry-template" type="text/x-handlebars-template"> <| </script>', {
+	test('Handlebar Completion', async () => {
+		await testCompletionFor('<script id="entry-template" type="text/x-handlebars-template"> <| </script>', {
 			items: [
 				{ label: 'div', resultText: '<script id="entry-template" type="text/x-handlebars-template"> <div </script>' }
 			]
 		});
 	});
 
-	test('Support script type="text/html"', function () {
-		testCompletionFor('<script id="html-template" type="text/html"> <| </script>', {
+	test('Support script type="text/html"', async () => {
+		await testCompletionFor('<script id="html-template" type="text/html"> <| </script>', {
 			items: [
 				{ label: 'div', resultText: '<script id="html-template" type="text/html"> <div </script>' }
 			]
 		});
 	});
 
-	test('Complete aria', function (): any {
+	test('Complete aria', async () => {
 		const expectedAriaAttributes = [
 			{ label: 'aria-activedescendant' },
 			{ label: 'aria-atomic' },
@@ -390,34 +390,34 @@ suite('HTML Completion', () => {
 			{ label: 'aria-valuetext' }
 		];
 
-		testCompletionFor('<div  |> </div >', { items: expectedAriaAttributes });
-		testCompletionFor('<span  |> </span >', { items: expectedAriaAttributes });
-		testCompletionFor('<input  |> </input >', { items: expectedAriaAttributes });
+		await testCompletionFor('<div  |> </div >', { items: expectedAriaAttributes });
+		await testCompletionFor('<span  |> </span >', { items: expectedAriaAttributes });
+		await testCompletionFor('<input  |> </input >', { items: expectedAriaAttributes });
 	});
 
-	test('Settings', function (): any {
-		testCompletionFor(
+	test('Settings', async () => {
+		await testCompletionFor(
 			'<|',
 			{
 				items: [{ label: 'div', notAvailable: true }]
 			},
 			{ html5: false }
 		);
-		testCompletionFor(
+		await testCompletionFor(
 			'<div clas|',
 			{
 				items: [{ label: 'class', resultText: '<div class="$1"' }]
 			},
 			{ attributeDefaultValue: 'doublequotes' }
 		);
-		testCompletionFor(
+		await testCompletionFor(
 			'<div clas|',
 			{
 				items: [{ label: 'class', resultText: '<div class=\'$1\'' }]
 			},
 			{ attributeDefaultValue: 'singlequotes' }
 		);
-		testCompletionFor(
+		await testCompletionFor(
 			'<div clas|',
 			{
 				items: [{ label: 'class', resultText: '<div class=$1' }]
@@ -426,55 +426,55 @@ suite('HTML Completion', () => {
 		);
 	});
 
-	test('doQuoteComplete', function (): any {
-		testQuoteCompletion('<a foo=|', '"$1"');
-		testQuoteCompletion('<a foo=|', '\'$1\'', { attributeDefaultValue: 'singlequotes'});
-		testQuoteCompletion('<a foo=|', null, { attributeDefaultValue: 'empty'});
-		testQuoteCompletion('<a foo=|=', null);
-		testQuoteCompletion('<a foo=|"bar"', null);
-		testQuoteCompletion('<a foo=|></a>', '"$1"');
-		testQuoteCompletion('<a foo="bar=|"', null);
-		testQuoteCompletion('<a baz=| foo="bar">', '"$1"');
-		testQuoteCompletion('<a>< foo=| /a>', null);
-		testQuoteCompletion('<a></ foo=| a>', null);
-		testQuoteCompletion('<a foo="bar" \n baz=| ></a>', '"$1"');
+	test('doQuoteComplete', async () => {
+		await testQuoteCompletion('<a foo=|', '"$1"');
+		await testQuoteCompletion('<a foo=|', '\'$1\'', { attributeDefaultValue: 'singlequotes'});
+		await testQuoteCompletion('<a foo=|', null, { attributeDefaultValue: 'empty'});
+		await testQuoteCompletion('<a foo=|=', null);
+		await testQuoteCompletion('<a foo=|"bar"', null);
+		await testQuoteCompletion('<a foo=|></a>', '"$1"');
+		await testQuoteCompletion('<a foo="bar=|"', null);
+		await testQuoteCompletion('<a baz=| foo="bar">', '"$1"');
+		await testQuoteCompletion('<a>< foo=| /a>', null);
+		await testQuoteCompletion('<a></ foo=| a>', null);
+		await testQuoteCompletion('<a foo="bar" \n baz=| ></a>', '"$1"');
 	});
 
-	test('doTagComplete', function (): any {
-		testTagCompletion('<div>|', '$0</div>');
-		testTagCompletion('<div>|</div>', null);
-		testTagCompletion('<div class="">|', '$0</div>');
-		testTagCompletion('<img>|', null);
-		testTagCompletion('<div><br></|', 'div>');
-		testTagCompletion('<div><br><span></span></|', 'div>');
-		testTagCompletion('<div><h1><br><span></span><img></| </h1></div>', 'h1>');
-		testTagCompletion('<ng-template><td><ng-template></|   </td> </ng-template>', 'ng-template>');
-		testTagCompletion('<div><br></|>', 'div');
+	test('doTagComplete', async () => {
+		await testTagCompletion('<div>|', '$0</div>');
+		await testTagCompletion('<div>|</div>', null);
+		await testTagCompletion('<div class="">|', '$0</div>');
+		await testTagCompletion('<img>|', null);
+		await testTagCompletion('<div><br></|', 'div>');
+		await testTagCompletion('<div><br><span></span></|', 'div>');
+		await testTagCompletion('<div><h1><br><span></span><img></| </h1></div>', 'h1>');
+		await testTagCompletion('<ng-template><td><ng-template></|   </td> </ng-template>', 'ng-template>');
+		await testTagCompletion('<div><br></|>', 'div');
 	});
 
-	test('Character entities', function (): any {
-		testCompletionFor('<div>&|', {
+	test('Character entities', async () => {
+		await testCompletionFor('<div>&|', {
 			items: [
 				{ label: '&hookrightarrow;', resultText: '<div>&hookrightarrow;' },
 				{ label: '&plus;', resultText: '<div>&plus;' }
 			]
 		});
-		testCompletionFor('<div>Hello&|', {
+		await testCompletionFor('<div>Hello&|', {
 			items: [{ label: '&ZeroWidthSpace;', resultText: '<div>Hello&ZeroWidthSpace;' }]
 		});
-		testCompletionFor('<div>Hello&gt|', {
+		await testCompletionFor('<div>Hello&gt|', {
 			items: [{ label: '&gtrdot;', resultText: '<div>Hello&gtrdot;' }]
 		});
-		testCompletionFor('<div class="&g|"', {
+		await testCompletionFor('<div class="&g|"', {
 			items: [{ label: '&grave;', resultText: '<div class="&grave;"' }]
 		});
-		testCompletionFor('<div class=&d|', {
+		await testCompletionFor('<div class=&d|', {
 			items: [{ label: '&duarr;', resultText: '<div class=&duarr;' }]
 		});
-		testCompletionFor('<div &d|', {
+		await testCompletionFor('<div &d|', {
 			items: [{ label: '&duarr;', notAvailable: true }]
 		});
-		testCompletionFor('<div&d|', {
+		await testCompletionFor('<div&d|', {
 			items: [{ label: '&duarr;', notAvailable: true }]
 		});
 	});
@@ -487,22 +487,22 @@ suite('HTML Completion', () => {
 	 * Todo @Pine: make this incomplete completion list, and only include
 	 * close tag suggestion after typing out </|
 	 */
-	test('filterText for close tag suggestion', () => {
-		testCompletionFor('<div> <| </div>', {
+	test('filterText for close tag suggestion', async () => {
+		await testCompletionFor('<div> <| </div>', {
 			items: [{ label: '/div', filterText: '/div' }]
 		});
 
-		testCompletionFor('<div>\n  <|\n</div>', {
+		await testCompletionFor('<div>\n  <|\n</div>', {
 			items: [{ label: '/div', filterText: '  </div' }]
 		});
 	});
 
-	test('non matching close tag suggestion', () => {
-		testCompletionFor('</|', {
+	test('non matching close tag suggestion', async () => {
+		await testCompletionFor('</|', {
 			items: [{ label: '/a', resultText: '</a>' }]
 		});
 
-		testCompletionFor('<div></div></|', {
+		await testCompletionFor('<div></div></|', {
 			items: [{ label: '/a', resultText: '<div></div></a>' }]
 		});
 	});

--- a/src/test/completionParticipant.test.ts
+++ b/src/test/completionParticipant.test.ts
@@ -28,7 +28,7 @@ suite('HTML Completion Participant', () => {
     return { document, position };
   };
 
-  const testHtmlAttributeValues = (value: string, expected: ExpectedHtmlAttributeValue[]): void => {
+  const testHtmlAttributeValues = async (value: string, expected: ExpectedHtmlAttributeValue[]): Promise<void> => {
     const ls = htmlLanguageService.getLanguageService();
     const { document, position } = prepareDocument(value);
 
@@ -47,7 +47,7 @@ suite('HTML Completion Participant', () => {
       }
     };
     ls.setCompletionParticipants([participant]);
-    const htmlDoc = ls.parseHTMLDocument(document);
+    const htmlDoc = await ls.parseHTMLDocument(document);
     const list = ls.doComplete(document, position, htmlDoc);
 
     const c = (a1: ExpectedHtmlAttributeValue, a2: ExpectedHtmlAttributeValue) => {
@@ -56,7 +56,7 @@ suite('HTML Completion Participant', () => {
     assert.deepEqual(actuals.sort(c), expected.sort(c));
   };
 
-  const testHtmlContent = (value: string, expected: ExpectedHtmlContent[]): void => {
+  const testHtmlContent = async (value: string, expected: ExpectedHtmlContent[]): Promise<void> => {
     const ls = htmlLanguageService.getLanguageService();
     const { document, position } = prepareDocument(value);
 
@@ -67,61 +67,61 @@ suite('HTML Completion Participant', () => {
       }
     };
     ls.setCompletionParticipants([participant]);
-    const htmlDoc = ls.parseHTMLDocument(document);
+    const htmlDoc = await ls.parseHTMLDocument(document);
     const list = ls.doComplete(document, position, htmlDoc);
     assert.deepEqual(actuals.length, expected.length);
   };
 
-  test('onHtmlAttributeValue', () => {
-    testHtmlAttributeValues('<|', []);
-    testHtmlAttributeValues('<div |>', []);
-    testHtmlAttributeValues('<div class|>', []);
-    testHtmlAttributeValues('<div>|', []);
-    testHtmlAttributeValues('<div>|</div>', []);
+  test('onHtmlAttributeValue', async () => {
+    await testHtmlAttributeValues('<|', []);
+    await testHtmlAttributeValues('<div |>', []);
+    await testHtmlAttributeValues('<div class|>', []);
+    await testHtmlAttributeValues('<div>|', []);
+    await testHtmlAttributeValues('<div>|</div>', []);
 
-    testHtmlAttributeValues('<div class="|"></div>', [{
+    await testHtmlAttributeValues('<div class="|"></div>', [{
       tag: 'div',
       attribute: 'class',
       value: '',
       replaceContent: '""'
     }]);
-    testHtmlAttributeValues('<div class="|f"></div>', [{
+    await testHtmlAttributeValues('<div class="|f"></div>', [{
       tag: 'div',
       attribute: 'class',
       value: '',
       replaceContent: '"f"'
     }]);
-    testHtmlAttributeValues('<div class="foo|"></div>', [{
+    await testHtmlAttributeValues('<div class="foo|"></div>', [{
       tag: 'div',
       attribute: 'class',
       value: 'foo',
       replaceContent: '"foo"'
     }]);
-    testHtmlAttributeValues(`<div class='foo'|></div>`, [{
+    await testHtmlAttributeValues(`<div class='foo'|></div>`, [{
       tag: 'div',
       attribute: 'class',
       value: '',
       replaceContent: `'foo'`
     }]);
-    testHtmlAttributeValues(`<div class=|'foo'></div>`, [{
+    await testHtmlAttributeValues(`<div class=|'foo'></div>`, [{
       tag: 'div',
       attribute: 'class',
       value: '',
       replaceContent: `'foo'`
     }]);
-    testHtmlAttributeValues(`<div class=|foo></div>`, [{
+    await testHtmlAttributeValues(`<div class=|foo></div>`, [{
       tag: 'div',
       attribute: 'class',
       value: '',
       replaceContent: 'foo'
     }]);
-    testHtmlAttributeValues(`<div class=foo|></div>`, [{
+    await testHtmlAttributeValues(`<div class=foo|></div>`, [{
       tag: 'div',
       attribute: 'class',
       value: 'foo',
       replaceContent: 'foo'
     }]);
-    testHtmlAttributeValues(`<div class=fo|o></div>`, [{
+    await testHtmlAttributeValues(`<div class=fo|o></div>`, [{
       tag: 'div',
       attribute: 'class',
       value: 'fo',
@@ -129,14 +129,14 @@ suite('HTML Completion Participant', () => {
     }]);
   });
 
-  test('onHtmlContent', () => {
-    testHtmlContent('<|', []);
-    testHtmlContent('<div |>', []);
-    testHtmlContent('<div class|>', []);
-    testHtmlContent('<div class="|">', []);
-    testHtmlContent('<div class="foo |">', []);
-    testHtmlContent('<div class="foo">d|', [{}]);
-    testHtmlContent('<div class="foo">d|</div>', [{}]);
+  test('onHtmlContent', async () => {
+    await testHtmlContent('<|', []);
+    await testHtmlContent('<div |>', []);
+    await testHtmlContent('<div class|>', []);
+    await testHtmlContent('<div class="|">', []);
+    await testHtmlContent('<div class="foo |">', []);
+    await testHtmlContent('<div class="foo">d|', [{}]);
+    await testHtmlContent('<div class="foo">d|</div>', [{}]);
   });
 
 });

--- a/src/test/completionUtil.ts
+++ b/src/test/completionUtil.ts
@@ -51,7 +51,7 @@ export function assertCompletion(completions: CompletionList, expected: ItemDesc
 	}
 }
 
-export function testCompletionFor(value: string, expected: { count?: number, items?: ItemDescription[] }, settings?: htmlLanguageService.CompletionConfiguration, lsOptions?: htmlLanguageService.LanguageServiceOptions): void {
+export async function testCompletionFor(value: string, expected: { count?: number, items?: ItemDescription[] }, settings?: htmlLanguageService.CompletionConfiguration, lsOptions?: htmlLanguageService.LanguageServiceOptions): Promise<void> {
 	const offset = value.indexOf('|');
 	value = value.substr(0, offset) + value.substr(offset + 1);
 
@@ -59,8 +59,8 @@ export function testCompletionFor(value: string, expected: { count?: number, ite
 
 	const document = TextDocument.create('test://test/test.html', 'html', 0, value);
 	const position = document.positionAt(offset);
-	const htmlDoc = ls.parseHTMLDocument(document);
-	const list = ls.doComplete(document, position, htmlDoc, settings);
+	const htmlDoc = await ls.parseHTMLDocument(document);
+	const list = await ls.doComplete(document, position, htmlDoc, settings);
 
 	// no duplicate labels
 	const labels = list.items.map(i => i.label).sort();
@@ -79,7 +79,7 @@ export function testCompletionFor(value: string, expected: { count?: number, ite
 	}
 }
 
-export function testQuoteCompletion(value: string, expected: string | null, options?: CompletionConfiguration): void {
+export async function testQuoteCompletion(value: string, expected: string | null, options?: CompletionConfiguration): Promise<void> {
 	const offset = value.indexOf('|');
 	value = value.substr(0, offset) + value.substr(offset + 1);
 
@@ -87,12 +87,12 @@ export function testQuoteCompletion(value: string, expected: string | null, opti
 
 	const document = TextDocument.create('test://test/test.html', 'html', 0, value);
 	const position = document.positionAt(offset);
-	const htmlDoc = ls.parseHTMLDocument(document);
+	const htmlDoc = await ls.parseHTMLDocument(document);
 	const actual = ls.doQuoteComplete(document, position, htmlDoc, options);
 	assert.strictEqual(actual, expected);
 }
 
-export function testTagCompletion(value: string, expected: string | null): void {
+export async function testTagCompletion(value: string, expected: string | null): Promise<void> {
 	const offset = value.indexOf('|');
 	value = value.substr(0, offset) + value.substr(offset + 1);
 
@@ -100,7 +100,7 @@ export function testTagCompletion(value: string, expected: string | null): void 
 
 	const document = TextDocument.create('test://test/test.html', 'html', 0, value);
 	const position = document.positionAt(offset);
-	const htmlDoc = ls.parseHTMLDocument(document);
-	const actual = ls.doTagComplete(document, position, htmlDoc);
+	const htmlDoc = await ls.parseHTMLDocument(document);
+	const actual = await ls.doTagComplete(document, position, htmlDoc);
 	assert.equal(actual, expected);
 }

--- a/src/test/customProviders.test.ts
+++ b/src/test/customProviders.test.ts
@@ -80,15 +80,15 @@ suite('HTML Custom Tag Provider', () => {
 
 	getLanguageService({ customDataProviders: [provider] });
 
-	test('Completion', () => {
-		testCompletionFor('<|', {
+	test('Completion', async () => {
+		await testCompletionFor('<|', {
 			items: [
 				{ label: 'foo', documentation: { kind: 'markdown', value: 'The `<foo>` element' }, resultText: '<foo' },
 				{ label: 'Bar', documentation: { kind: 'markdown', value: 'The `<Bar>` element' }, resultText: '<Bar' }
 			]
 		}, undefined, languageOptions);
 
-		testCompletionFor('<foo |', {
+		await testCompletionFor('<foo |', {
 			items: [
 				{
 					label: 'bar',
@@ -108,7 +108,7 @@ suite('HTML Custom Tag Provider', () => {
 			]
 		}, undefined, languageOptions);
 
-		testCompletionFor('<foo bar=|', {
+		await testCompletionFor('<foo bar=|', {
 			items: [
 				{
 					label: 'baz',
@@ -118,7 +118,7 @@ suite('HTML Custom Tag Provider', () => {
 			]
 		}, undefined, languageOptions);
 
-		testCompletionFor('<foo xattr=|', {
+		await testCompletionFor('<foo xattr=|', {
 			items: [
 				{
 					label: 'xval',
@@ -128,7 +128,7 @@ suite('HTML Custom Tag Provider', () => {
 			]
 		}, undefined, languageOptions);
 
-		testCompletionFor('<Bar |', {
+		await testCompletionFor('<Bar |', {
 			items: [
 				{
 					label: 'Xoo'
@@ -137,7 +137,7 @@ suite('HTML Custom Tag Provider', () => {
 		}, undefined, languageOptions);
 
 		// test global attributes
-		testCompletionFor('<other |', {
+		await testCompletionFor('<other |', {
 			items: [
 				{
 					label: 'fooAttr',
@@ -152,7 +152,7 @@ suite('HTML Custom Tag Provider', () => {
 			]
 		}, undefined, languageOptions);
 
-		testCompletionFor('<other xattr=|', {
+		await testCompletionFor('<other xattr=|', {
 			items: [
 				{
 					label: 'xval',
@@ -163,15 +163,15 @@ suite('HTML Custom Tag Provider', () => {
 		}, undefined, languageOptions);
 	});
 
-	test('Hover', () => {
-		assertHover2('<f|oo></foo>', { kind: 'markdown', value: 'The `<foo>` element' }, 'foo', languageOptions);
+	test('Hover', async () => {
+		await assertHover2('<f|oo></foo>', { kind: 'markdown', value: 'The `<foo>` element' }, 'foo', languageOptions);
 
-		assertHover2('<foo |bar></foo>', { kind: 'markdown', value: 'The `<foo bar>` attribute' }, 'bar', languageOptions);
-		assertHover2('<foo |xattr></foo>', { kind: 'markdown', value: '`xattr` attributes' }, 'xattr', languageOptions);
+		await assertHover2('<foo |bar></foo>', { kind: 'markdown', value: 'The `<foo bar>` attribute' }, 'bar', languageOptions);
+		await assertHover2('<foo |xattr></foo>', { kind: 'markdown', value: '`xattr` attributes' }, 'xattr', languageOptions);
 
-		assertHover2('<foo bar="|baz"></foo>', { kind: 'markdown', value: 'The `<foo bar="baz">` attribute' }, '"baz"', languageOptions);
-		assertHover2('<foo xattr="|xval"></foo>', { kind: 'markdown', value: '`xval` value' }, '"xval"', languageOptions);
+		await assertHover2('<foo bar="|baz"></foo>', { kind: 'markdown', value: 'The `<foo bar="baz">` attribute' }, '"baz"', languageOptions);
+		await assertHover2('<foo xattr="|xval"></foo>', { kind: 'markdown', value: '`xval` value' }, '"xval"', languageOptions);
 
-		assertHover2('<foo foo="xval" xattr="|xval"></foo>', { kind: 'markdown', value: '`xval` value' }, '"xval"', languageOptions);
+		await assertHover2('<foo foo="xval" xattr="|xval"></foo>', { kind: 'markdown', value: '`xval` value' }, '"xval"', languageOptions);
 	});
 });

--- a/src/test/folding.test.ts
+++ b/src/test/folding.test.ts
@@ -16,13 +16,13 @@ interface ExpectedIndentRange {
 	kind?: string;
 }
 
-function assertRanges(lines: string[], expected: ExpectedIndentRange[], message?: string, nRanges?: number): void {
+async function assertRanges(lines: string[], expected: ExpectedIndentRange[], message?: string, nRanges?: number): Promise<void> {
 	const document = TextDocument.create('test://foo/bar.json', 'json', 1, lines.join('\n'));
 	const workspace = {
 		settings: {},
 		folders: [{ name: 'foo', uri: 'test://foo' }]
 	};
-	const actual = new HTMLFolding(new HTMLDataManager({})).getFoldingRanges(document, { rangeLimit: nRanges });
+	const actual = await new HTMLFolding(new HTMLDataManager({})).getFoldingRanges(document, { rangeLimit: nRanges });
 
 	let actualRanges = [];
 	for (let i = 0; i < actual.length; i++) {
@@ -37,16 +37,16 @@ function r(startLine: number, endLine: number, kind?: string): ExpectedIndentRan
 }
 
 suite('HTML Folding', () => {
-	test('Fold one level', () => {
+	test('Fold one level', async () => {
 		const input = [
 			/*0*/'<html>',
 			/*1*/'Hello',
 			/*2*/'</html>'
 		];
-		assertRanges(input, [r(0, 1)]);
+		await assertRanges(input, [r(0, 1)]);
 	});
 
-	test('Fold two level', () => {
+	test('Fold two level', async () => {
 		const input = [
 			/*0*/'<html>',
 			/*1*/'<head>',
@@ -54,10 +54,10 @@ suite('HTML Folding', () => {
 			/*3*/'</head>',
 			/*4*/'</html>'
 		];
-		assertRanges(input, [r(0, 3), r(1, 2)]);
+		await assertRanges(input, [r(0, 3), r(1, 2)]);
 	});
 
-	test('Fold siblings', () => {
+	test('Fold siblings', async () => {
 		const input = [
 			/*0*/'<html>',
 			/*1*/'<head>',
@@ -68,10 +68,10 @@ suite('HTML Folding', () => {
 			/*6*/'</body>',
 			/*7*/'</html>'
 		];
-		assertRanges(input, [r(0, 6), r(1, 2), r(4, 5)]);
+		await assertRanges(input, [r(0, 6), r(1, 2), r(4, 5)]);
 	});
 
-	test('Fold self-closing tags', () => {
+	test('Fold self-closing tags', async () => {
 		const input = [
 			/*0*/'<div>',
 			/*1*/'<a href="top"/>',
@@ -83,10 +83,10 @@ suite('HTML Folding', () => {
 			/*7*/'>',
 			/*8*/'</div>'
 		];
-		assertRanges(input, [r(0, 7), r(5, 6)]);
+		await assertRanges(input, [r(0, 7), r(5, 6)]);
 	});
 
-	test('Fold comment', () => {
+	test('Fold comment', async () => {
 		const input = [
 			/*0*/'<!--',
 			/*1*/' multi line',
@@ -94,22 +94,22 @@ suite('HTML Folding', () => {
 			/*3*/'<!-- some stuff',
 			/*4*/' some more stuff -->',
 		];
-		assertRanges(input, [r(0, 2, 'comment'), r(3, 4, 'comment')]);
+		await assertRanges(input, [r(0, 2, 'comment'), r(3, 4, 'comment')]);
 	});
 
-	test('Fold regions', () => {
+	test('Fold regions', async () => {
 		const input = [
 			/*0*/'<!-- #region -->',
 			/*1*/'<!-- #region -->',
 			/*2*/'<!-- #endregion -->',
 			/*3*/'<!-- #endregion -->',
 		];
-		assertRanges(input, [r(0, 3, 'region'), r(1, 2, 'region')]);
+		await assertRanges(input, [r(0, 3, 'region'), r(1, 2, 'region')]);
 	});
 
 
 
-	test('Fold incomplete', () => {
+	test('Fold incomplete', async () => {
 		const input = [
 			/*0*/'<body>',
 			/*1*/'<div></div>',
@@ -117,19 +117,19 @@ suite('HTML Folding', () => {
 			/*3*/'</div>',
 			/*4*/'</body>',
 		];
-		assertRanges(input, [r(0, 3)]);
+		await assertRanges(input, [r(0, 3)]);
 	});
 
-	test('Fold incomplete 2', () => {
+	test('Fold incomplete 2', async () => {
 		const input = [
 			/*0*/'<be><div>',
 			/*1*/'<!-- #endregion -->',
 			/*2*/'</div>',
 		];
-		assertRanges(input, [r(0, 1)]);
+		await assertRanges(input, [r(0, 1)]);
 	});
 
-	test('Fold intersecting region', () => {
+	test('Fold intersecting region', async () => {
 		const input = [
 			/*0*/'<body>',
 			/*1*/'<!-- #region -->',
@@ -138,10 +138,10 @@ suite('HTML Folding', () => {
 			/*4*/'</body>',
 			/*5*/'<!-- #endregion -->',
 		];
-		assertRanges(input, [r(0, 3)]);
+		await assertRanges(input, [r(0, 3)]);
 	});
 
-	test('Fold intersecting region 2', () => {
+	test('Fold intersecting region 2', async () => {
 		const input = [
 			/*0*/'<!-- #region -->',
 			/*1*/'<body>',
@@ -150,10 +150,10 @@ suite('HTML Folding', () => {
 			/*4*/'<div></div>',
 			/*5*/'</body>',
 		];
-		assertRanges(input, [r(0, 3, 'region')]);
+		await assertRanges(input, [r(0, 3, 'region')]);
 	});
 
-	test('Test limit', () => {
+	test('Test limit', async () => {
 		const input = [
 			/* 0*/'<div>',
 			/* 1*/' <span>',
@@ -177,15 +177,15 @@ suite('HTML Folding', () => {
 			/*19*/' </span>',
 			/*20*/'</div>',
 		];
-		assertRanges(input, [r(0, 19), r(1, 18), r(2, 3), r(5, 11), r(6, 7), r(9, 10), r(13, 14), r(16, 17)], 'no limit', void 0);
-		assertRanges(input, [r(0, 19), r(1, 18), r(2, 3), r(5, 11), r(6, 7), r(9, 10), r(13, 14), r(16, 17)], 'limit 8', 8);
-		assertRanges(input, [r(0, 19), r(1, 18), r(2, 3), r(5, 11), r(6, 7), r(13, 14), r(16, 17)], 'limit 7', 7);
-		assertRanges(input, [r(0, 19), r(1, 18), r(2, 3), r(5, 11), r(13, 14), r(16, 17)], 'limit 6', 6);
-		assertRanges(input, [r(0, 19), r(1, 18), r(2, 3), r(5, 11), r(13, 14)], 'limit 5', 5);
-		assertRanges(input, [r(0, 19), r(1, 18), r(2, 3), r(5, 11)], 'limit 4', 4);
-		assertRanges(input, [r(0, 19), r(1, 18), r(2, 3)], 'limit 3', 3);
-		assertRanges(input, [r(0, 19), r(1, 18)], 'limit 2', 2);
-		assertRanges(input, [r(0, 19)], 'limit 1', 1);
+		await assertRanges(input, [r(0, 19), r(1, 18), r(2, 3), r(5, 11), r(6, 7), r(9, 10), r(13, 14), r(16, 17)], 'no limit', void 0);
+		await assertRanges(input, [r(0, 19), r(1, 18), r(2, 3), r(5, 11), r(6, 7), r(9, 10), r(13, 14), r(16, 17)], 'limit 8', 8);
+		await assertRanges(input, [r(0, 19), r(1, 18), r(2, 3), r(5, 11), r(6, 7), r(13, 14), r(16, 17)], 'limit 7', 7);
+		await assertRanges(input, [r(0, 19), r(1, 18), r(2, 3), r(5, 11), r(13, 14), r(16, 17)], 'limit 6', 6);
+		await assertRanges(input, [r(0, 19), r(1, 18), r(2, 3), r(5, 11), r(13, 14)], 'limit 5', 5);
+		await assertRanges(input, [r(0, 19), r(1, 18), r(2, 3), r(5, 11)], 'limit 4', 4);
+		await assertRanges(input, [r(0, 19), r(1, 18), r(2, 3)], 'limit 3', 3);
+		await assertRanges(input, [r(0, 19), r(1, 18)], 'limit 2', 2);
+		await assertRanges(input, [r(0, 19)], 'limit 1', 1);
 	});
 
 });

--- a/src/test/highlighting.test.ts
+++ b/src/test/highlighting.test.ts
@@ -12,7 +12,7 @@ import { TextDocument } from '../htmlLanguageService';
 suite('HTML Highlighting', () => {
 
 
-	function assertHighlights(value: string, expectedMatches: number[], elementName: string | null): void {
+	async function assertHighlights(value: string, expectedMatches: number[], elementName: string | null): Promise<void> {
 		const offset = value.indexOf('|');
 		value = value.substr(0, offset) + value.substr(offset + 1);
 
@@ -20,7 +20,7 @@ suite('HTML Highlighting', () => {
 
 		const position = document.positionAt(offset);
 		const ls = htmlLanguageService.getLanguageService();
-		const htmlDoc = ls.parseHTMLDocument(document);
+		const htmlDoc = await ls.parseHTMLDocument(document);
 
 		const highlights = ls.findDocumentHighlights(document, position, htmlDoc);
 		assert.equal(highlights.length, expectedMatches.length);
@@ -34,47 +34,47 @@ suite('HTML Highlighting', () => {
 		}
 	}
 
-	test('Single', function (): any {
-		assertHighlights('|<html></html>', [], null);
-		assertHighlights('<|html></html>', [1, 8], 'html');
-		assertHighlights('<h|tml></html>', [1, 8], 'html');
-		assertHighlights('<htm|l></html>', [1, 8], 'html');
-		assertHighlights('<html|></html>', [1, 8], 'html');
-		assertHighlights('<html>|</html>', [], null);
-		assertHighlights('<html><|/html>', [], null);
-		assertHighlights('<html></|html>', [1, 8], 'html');
-		assertHighlights('<html></h|tml>', [1, 8], 'html');
-		assertHighlights('<html></ht|ml>', [1, 8], 'html');
-		assertHighlights('<html></htm|l>', [1, 8], 'html');
-		assertHighlights('<html></html|>', [1, 8], 'html');
-		assertHighlights('<html></html>|', [], null);
+	test('Single', async () => {
+		await assertHighlights('|<html></html>', [], null);
+		await assertHighlights('<|html></html>', [1, 8], 'html');
+		await assertHighlights('<h|tml></html>', [1, 8], 'html');
+		await assertHighlights('<htm|l></html>', [1, 8], 'html');
+		await assertHighlights('<html|></html>', [1, 8], 'html');
+		await assertHighlights('<html>|</html>', [], null);
+		await assertHighlights('<html><|/html>', [], null);
+		await assertHighlights('<html></|html>', [1, 8], 'html');
+		await assertHighlights('<html></h|tml>', [1, 8], 'html');
+		await assertHighlights('<html></ht|ml>', [1, 8], 'html');
+		await assertHighlights('<html></htm|l>', [1, 8], 'html');
+		await assertHighlights('<html></html|>', [1, 8], 'html');
+		await assertHighlights('<html></html>|', [], null);
 	});
 
-	test('Nested', function (): any {
-		assertHighlights('<html>|<div></div></html>', [], null);
-		assertHighlights('<html><|div></div></html>', [7, 13], 'div');
-		assertHighlights('<html><div>|</div></html>', [], null);
-		assertHighlights('<html><div></di|v></html>', [7, 13], 'div');
-		assertHighlights('<html><div><div></div></di|v></html>', [7, 24], 'div');
-		assertHighlights('<html><div><div></div|></div></html>', [12, 18], 'div');
-		assertHighlights('<html><div><div|></div></div></html>', [12, 18], 'div');
-		assertHighlights('<html><div><div></div></div></h|tml>', [1, 30], 'html');
-		assertHighlights('<html><di|v></div><div></div></html>', [7, 13], 'div');
-		assertHighlights('<html><div></div><div></d|iv></html>', [18, 24], 'div');
+	test('Nested', async () => {
+		await assertHighlights('<html>|<div></div></html>', [], null);
+		await assertHighlights('<html><|div></div></html>', [7, 13], 'div');
+		await assertHighlights('<html><div>|</div></html>', [], null);
+		await assertHighlights('<html><div></di|v></html>', [7, 13], 'div');
+		await assertHighlights('<html><div><div></div></di|v></html>', [7, 24], 'div');
+		await assertHighlights('<html><div><div></div|></div></html>', [12, 18], 'div');
+		await assertHighlights('<html><div><div|></div></div></html>', [12, 18], 'div');
+		await assertHighlights('<html><div><div></div></div></h|tml>', [1, 30], 'html');
+		await assertHighlights('<html><di|v></div><div></div></html>', [7, 13], 'div');
+		await assertHighlights('<html><div></div><div></d|iv></html>', [18, 24], 'div');
 	});
 
-	test('Selfclosed', function (): any {
-		assertHighlights('<html><|div/></html>', [7], 'div');
-		assertHighlights('<html><|br></html>', [7], 'br');
-		assertHighlights('<html><div><d|iv/></div></html>', [12], 'div');
+	test('Selfclosed', async () => {
+		await assertHighlights('<html><|div/></html>', [7], 'div');
+		await assertHighlights('<html><|br></html>', [7], 'br');
+		await assertHighlights('<html><div><d|iv/></div></html>', [12], 'div');
 	});
 
-	test('Case insensivity', function (): any {
-		assertHighlights('<HTML><diV><Div></dIV></dI|v></html>', [7, 24], 'div');
-		assertHighlights('<HTML><diV|><Div></dIV></dIv></html>', [7, 24], 'div');
+	test('Case insensivity', async () => {
+		await assertHighlights('<HTML><diV><Div></dIV></dI|v></html>', [7, 24], 'div');
+		await assertHighlights('<HTML><diV|><Div></dIV></dIv></html>', [7, 24], 'div');
 	});
 
-	test('Incomplete', function (): any {
-		assertHighlights('<div><ol><li></li></ol></p></|div>', [1, 29], 'div');
+	test('Incomplete', async () => {
+		await assertHighlights('<div><ol><li></li></ol></p></|div>', [1, 29], 'div');
 	});
 });

--- a/src/test/hover.test.ts
+++ b/src/test/hover.test.ts
@@ -7,7 +7,7 @@ import { assertHover, assertHover2 } from './hoverUtil';
 import { MarkupContent } from '../htmlLanguageTypes';
 
 suite('HTML Hover', () => {
-	test('Single', function (): any {
+	test('Single', async () => {
 		const descriptionAndReference =
 			'The html element represents the root of an HTML document.' +
 			'\n\n' +
@@ -25,38 +25,38 @@ suite('HTML Hover', () => {
 		const entityDescription = `Character entity representing '\u00A0', unicode equivalent 'U+00A0'`;
 
 
-		assertHover('|<html></html>', void 0, void 0);
-		assertHover('<|html></html>', htmlContent, 1);
-		assertHover('<h|tml></html>', htmlContent, 1);
-		assertHover('<htm|l></html>', htmlContent, 1);
-		assertHover('<html|></html>', htmlContent, 1);
-		assertHover('<html>|</html>', void 0, void 0);
-		assertHover('<html><|/html>', void 0, void 0);
-		assertHover('<html></|html>', closeHtmlContent, 8);
-		assertHover('<html></h|tml>', closeHtmlContent, 8);
-		assertHover('<html></ht|ml>', closeHtmlContent, 8);
-		assertHover('<html></htm|l>', closeHtmlContent, 8);
-		assertHover('<html></html|>', closeHtmlContent, 8);
-		assertHover('<html></html>|', void 0, void 0);
+		await assertHover('|<html></html>', void 0, void 0);
+		await assertHover('<|html></html>', htmlContent, 1);
+		await assertHover('<h|tml></html>', htmlContent, 1);
+		await assertHover('<htm|l></html>', htmlContent, 1);
+		await assertHover('<html|></html>', htmlContent, 1);
+		await assertHover('<html>|</html>', void 0, void 0);
+		await assertHover('<html><|/html>', void 0, void 0);
+		await assertHover('<html></|html>', closeHtmlContent, 8);
+		await assertHover('<html></h|tml>', closeHtmlContent, 8);
+		await assertHover('<html></ht|ml>', closeHtmlContent, 8);
+		await assertHover('<html></htm|l>', closeHtmlContent, 8);
+		await assertHover('<html></html|>', closeHtmlContent, 8);
+		await assertHover('<html></html>|', void 0, void 0);
 
-		assertHover2('<html>|&nbsp;</html>', '', '');
-		assertHover2('<html>&|nbsp;</html>', entityDescription, 'nbsp;');
-		assertHover2('<html>&n|bsp;</html>', entityDescription, 'nbsp;');
-		assertHover2('<html>&nb|sp;</html>', entityDescription, 'nbsp;');
-		assertHover2('<html>&nbs|p;</html>', entityDescription, 'nbsp;');
-		assertHover2('<html>&nbsp|;</html>', entityDescription, 'nbsp;');
-		assertHover2('<html>&nbsp;|</html>', '', '');
+		await assertHover2('<html>|&nbsp;</html>', '', '');
+		await assertHover2('<html>&|nbsp;</html>', entityDescription, 'nbsp;');
+		await assertHover2('<html>&n|bsp;</html>', entityDescription, 'nbsp;');
+		await assertHover2('<html>&nb|sp;</html>', entityDescription, 'nbsp;');
+		await assertHover2('<html>&nbs|p;</html>', entityDescription, 'nbsp;');
+		await assertHover2('<html>&nbsp|;</html>', entityDescription, 'nbsp;');
+		await assertHover2('<html>&nbsp;|</html>', '', '');
 
 		const noDescription: MarkupContent = {
 			kind: 'markdown',
 			value: '[MDN Reference](https://developer.mozilla.org/docs/Web/HTML/Element/html)'
 		};
-		assertHover2('<html|></html>', noDescription, 'html', undefined, { documentation: false });
+		await assertHover2('<html|></html>', noDescription, 'html', undefined, { documentation: false });
 
 		const noReferences: MarkupContent = {
 			kind: 'markdown',
 			value: 'The html element represents the root of an HTML document.'
 		};
-		assertHover2('<html|></html>', noReferences, 'html', undefined, { references: false });
+		await assertHover2('<html|></html>', noReferences, 'html', undefined, { references: false });
 	});
 });

--- a/src/test/hoverUtil.ts
+++ b/src/test/hoverUtil.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as htmlLanguageService from '../htmlLanguageService';
 import { HoverSettings, TextDocument, MarkupContent } from '../htmlLanguageService';
 
-export function assertHover(value: string, expectedHoverContent: MarkupContent | undefined, expectedHoverOffset: number | undefined): void {
+export async function assertHover(value: string, expectedHoverContent: MarkupContent | undefined, expectedHoverOffset: number | undefined): Promise<void> {
 	const offset = value.indexOf('|');
 	value = value.substr(0, offset) + value.substr(offset + 1);
 
@@ -15,14 +15,14 @@ export function assertHover(value: string, expectedHoverContent: MarkupContent |
 
 	const position = document.positionAt(offset);
 	const ls = htmlLanguageService.getLanguageService();
-	const htmlDoc = ls.parseHTMLDocument(document);
+	const htmlDoc = await ls.parseHTMLDocument(document);
 
-	const hover = ls.doHover(document, position, htmlDoc);
+	const hover = await ls.doHover(document, position, htmlDoc);
 	assert.deepEqual(hover && hover.contents, expectedHoverContent);
 	assert.equal(hover && document.offsetAt(hover.range!.start), expectedHoverOffset);
 }
 
-export function assertHover2(value: string, contents: string | MarkupContent, rangeText: string, lsOptions?: htmlLanguageService.LanguageServiceOptions, hoverSettings?: HoverSettings): void {
+export async function assertHover2(value: string, contents: string | MarkupContent, rangeText: string, lsOptions?: htmlLanguageService.LanguageServiceOptions, hoverSettings?: HoverSettings): Promise<void> {
 	const offset = value.indexOf('|');
 	value = value.substr(0, offset) + value.substr(offset + 1);
 
@@ -30,9 +30,9 @@ export function assertHover2(value: string, contents: string | MarkupContent, ra
 
 	const position = document.positionAt(offset);
 	const ls = htmlLanguageService.getLanguageService(lsOptions);
-	const htmlDoc = ls.parseHTMLDocument(document);
+	const htmlDoc = await ls.parseHTMLDocument(document);
 
-	const hover = ls.doHover(document, position, htmlDoc, hoverSettings);
+	const hover = await ls.doHover(document, position, htmlDoc, hoverSettings);
 	if (hover) {
 		if (typeof contents === 'string') {
 			assert.equal(hover.contents, contents);

--- a/src/test/linkedEditing.test.ts
+++ b/src/test/linkedEditing.test.ts
@@ -12,7 +12,7 @@ interface OffsetWithText {
   1: string;
 }
 
-export function testMatchingTagPosition(value: string, expected: OffsetWithText[]): void {
+export async function testMatchingTagPosition(value: string, expected: OffsetWithText[]): Promise<void> {
   const originalValue = value;
 
   let offset = value.indexOf('|');
@@ -22,7 +22,7 @@ export function testMatchingTagPosition(value: string, expected: OffsetWithText[
 
   const document = TextDocument.create('test://test/test.html', 'html', 0, value);
   const position = document.positionAt(offset);
-  const htmlDoc = ls.parseHTMLDocument(document);
+  const htmlDoc = await ls.parseHTMLDocument(document);
 
   const syncedRegions = ls.findLinkedEditingRanges(document, position, htmlDoc);
   if (!syncedRegions) {
@@ -41,29 +41,29 @@ export function testMatchingTagPosition(value: string, expected: OffsetWithText[
 }
 
 suite('HTML Linked Editing', () => {
-  test('Linked Editing', () => {
-    testMatchingTagPosition('|<div></div>', []);
-    testMatchingTagPosition('<|div></div>', [[1, 'div'], [7, 'div']]);
-    testMatchingTagPosition('<d|iv></div>', [[1, 'div'], [7, 'div']]);
-    testMatchingTagPosition('<di|v></div>', [[1, 'div'], [7, 'div']]);
-    testMatchingTagPosition('<div|></div>', [[1, 'div'], [7, 'div']]);
+  test('Linked Editing', async () => {
+    await testMatchingTagPosition('|<div></div>', []);
+    await testMatchingTagPosition('<|div></div>', [[1, 'div'], [7, 'div']]);
+    await testMatchingTagPosition('<d|iv></div>', [[1, 'div'], [7, 'div']]);
+    await testMatchingTagPosition('<di|v></div>', [[1, 'div'], [7, 'div']]);
+    await testMatchingTagPosition('<div|></div>', [[1, 'div'], [7, 'div']]);
 
-    testMatchingTagPosition('<div>|</div>', []);
-    testMatchingTagPosition('<div><|/div>', []);
+    await testMatchingTagPosition('<div>|</div>', []);
+    await testMatchingTagPosition('<div><|/div>', []);
 
-    testMatchingTagPosition('<div></|div>', [[1, 'div'], [7, 'div']]);
-    testMatchingTagPosition('<div></d|iv>', [[1, 'div'], [7, 'div']]);
-    testMatchingTagPosition('<div></di|v>', [[1, 'div'], [7, 'div']]);
-    testMatchingTagPosition('<div></div|>', [[1, 'div'], [7, 'div']]);
+    await testMatchingTagPosition('<div></|div>', [[1, 'div'], [7, 'div']]);
+    await testMatchingTagPosition('<div></d|iv>', [[1, 'div'], [7, 'div']]);
+    await testMatchingTagPosition('<div></di|v>', [[1, 'div'], [7, 'div']]);
+    await testMatchingTagPosition('<div></div|>', [[1, 'div'], [7, 'div']]);
 
-    testMatchingTagPosition('<div></div>|', []);
-    testMatchingTagPosition('<div><div|</div>', []);
-    testMatchingTagPosition('<div><div><div|</div></div>', []);
+    await testMatchingTagPosition('<div></div>|', []);
+    await testMatchingTagPosition('<div><div|</div>', []);
+    await testMatchingTagPosition('<div><div><div|</div></div>', []);
 
-    testMatchingTagPosition('<div| ></div>', [[1, 'div'], [8, 'div']]);
-    testMatchingTagPosition('<div| id="foo"></div>', [[1, 'div'], [16, 'div']]);
+    await testMatchingTagPosition('<div| ></div>', [[1, 'div'], [8, 'div']]);
+    await testMatchingTagPosition('<div| id="foo"></div>', [[1, 'div'], [16, 'div']]);
 
-    testMatchingTagPosition('<|></>', [[1, ''], [4, '']]);
-    testMatchingTagPosition('<><div></div></|>', [[1, ''], [15, '']]);
+    await testMatchingTagPosition('<|></>', [[1, ''], [4, '']]);
+    await testMatchingTagPosition('<><div></div></|>', [[1, ''], [15, '']]);
   });
 });

--- a/src/test/matchingTagPosition.test.ts
+++ b/src/test/matchingTagPosition.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as htmlLanguageService from '../htmlLanguageService';
 import { TextDocument } from '../htmlLanguageService';
 
-export function testMatchingTagPosition(value: string): void {
+export async function testMatchingTagPosition(value: string): Promise<void> {
   let offset = value.indexOf('|');
   value = value.substr(0, offset) + value.substr(offset + 1);
   const mirrorOffset = value.indexOf('$');
@@ -20,7 +20,7 @@ export function testMatchingTagPosition(value: string): void {
 
   const document = TextDocument.create('test://test/test.html', 'html', 0, value);
   const position = document.positionAt(offset);
-  const htmlDoc = ls.parseHTMLDocument(document);
+  const htmlDoc = await ls.parseHTMLDocument(document);
 
   const mirrorPosition = ls.findMatchingTagPosition(document, position, htmlDoc);
   if (!mirrorPosition) {
@@ -34,21 +34,21 @@ export function testMatchingTagPosition(value: string): void {
 }
 
 suite('HTML find matching tag position', () => {
-  test('Matching position', () => {
-    testMatchingTagPosition('<|div></$div>');
-    testMatchingTagPosition('<d|iv></d$iv>');
-    testMatchingTagPosition('<di|v></di$v>');
-    testMatchingTagPosition('<div|></div$>');
+  test('Matching position', async () => {
+    await testMatchingTagPosition('<|div></$div>');
+    await testMatchingTagPosition('<d|iv></d$iv>');
+    await testMatchingTagPosition('<di|v></di$v>');
+    await testMatchingTagPosition('<div|></div$>');
 
-    testMatchingTagPosition('<$div></|div>');
-    testMatchingTagPosition('<d$iv></d|iv>');
-    testMatchingTagPosition('<di$v></di|v>');
-    testMatchingTagPosition('<div$></div|>');
+    await testMatchingTagPosition('<$div></|div>');
+    await testMatchingTagPosition('<d$iv></d|iv>');
+    await testMatchingTagPosition('<di$v></di|v>');
+    await testMatchingTagPosition('<div$></div|>');
 
-    testMatchingTagPosition('<div| ></div$>');
-    testMatchingTagPosition('<div| id="foo"></div$>');
+    await testMatchingTagPosition('<div| ></div$>');
+    await testMatchingTagPosition('<div| id="foo"></div$>');
 
-    testMatchingTagPosition('<div$ ></div|>');
-    testMatchingTagPosition('<div$ id="foo"></div|>');
+    await testMatchingTagPosition('<div$ ></div|>');
+    await testMatchingTagPosition('<div$ id="foo"></div|>');
   });
 });

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -8,9 +8,10 @@ import { HTMLParser, Node } from '../parser/htmlParser';
 import { HTMLDataManager } from '../languageFacts/dataManager';
 
 suite('HTML Parser', () => {
-	function parse(text: string) {
+	async function parse(text: string) {
 		const htmlDataManager = new HTMLDataManager({});
-		return new HTMLParser(htmlDataManager).parse(text, htmlDataManager.getVoidElements('html'));
+		const voidElements = await htmlDataManager.getVoidElements('html');
+		return new HTMLParser(htmlDataManager).parse(text, voidElements);
 	}
 	function toJSON(node: Node): any {
 		return { tag: node.tag, start: node.start, end: node.end, endTagStart: node.endTagStart, closed: node.closed, children: node.children.map(toJSON) };
@@ -20,36 +21,36 @@ suite('HTML Parser', () => {
 		return { tag: node.tag, attributes: node.attributes, children: node.children.map(toJSONWithAttributes) };
 	}
 
-	function assertDocument(input: string, expected: any) {
-		const document = parse(input);
+	async function assertDocument(input: string, expected: any) {
+		const document = await parse(input);
 		assert.deepEqual(document.roots.map(toJSON), expected);
 	}
 
-	function assertNodeBefore(input: string, offset: number, expectedTag: string | undefined) {
-		const document = parse(input);
+	async function assertNodeBefore(input: string, offset: number, expectedTag: string | undefined) {
+		const document = await parse(input);
 		const node = document.findNodeBefore(offset);
 		assert.equal(node ? node.tag : '', expectedTag, "offset " + offset);
 	}
 
-	function assertAttributes(input: string, expected: any) {
-		const document = parse(input);
+	async function assertAttributes(input: string, expected: any) {
+		const document = await parse(input);
 		assert.deepEqual(document.roots.map(toJSONWithAttributes), expected);
 	}
 
-	test('Simple', () => {
-		assertDocument('<html></html>', [{ tag: 'html', start: 0, end: 13, endTagStart: 6, closed: true, children: [] }]);
-		assertDocument('<html><body></body></html>', [{ tag: 'html', start: 0, end: 26, endTagStart: 19, closed: true, children: [{ tag: 'body', start: 6, end: 19, endTagStart: 12, closed: true, children: [] }] }]);
-		assertDocument('<html><head></head><body></body></html>', [{ tag: 'html', start: 0, end: 39, endTagStart: 32, closed: true, children: [{ tag: 'head', start: 6, end: 19, endTagStart: 12, closed: true, children: [] }, { tag: 'body', start: 19, end: 32, endTagStart: 25, closed: true, children: [] }] }]);
+	test('Simple', async () => {
+		await assertDocument('<html></html>', [{ tag: 'html', start: 0, end: 13, endTagStart: 6, closed: true, children: [] }]);
+		await assertDocument('<html><body></body></html>', [{ tag: 'html', start: 0, end: 26, endTagStart: 19, closed: true, children: [{ tag: 'body', start: 6, end: 19, endTagStart: 12, closed: true, children: [] }] }]);
+		await assertDocument('<html><head></head><body></body></html>', [{ tag: 'html', start: 0, end: 39, endTagStart: 32, closed: true, children: [{ tag: 'head', start: 6, end: 19, endTagStart: 12, closed: true, children: [] }, { tag: 'body', start: 19, end: 32, endTagStart: 25, closed: true, children: [] }] }]);
 	});
 
-	test('SelfClose', () => {
-		assertDocument('<br/>', [{ tag: 'br', start: 0, end: 5, endTagStart: void 0, closed: true, children: [] }]);
-		assertDocument('<div><br/><span></span></div>', [{ tag: 'div', start: 0, end: 29, endTagStart: 23, closed: true, children: [{ tag: 'br', start: 5, end: 10, endTagStart: void 0, closed: true, children: [] }, { tag: 'span', start: 10, end: 23, endTagStart: 16, closed: true, children: [] }] }]);
+	test('SelfClose', async () => {
+		await assertDocument('<br/>', [{ tag: 'br', start: 0, end: 5, endTagStart: void 0, closed: true, children: [] }]);
+		await assertDocument('<div><br/><span></span></div>', [{ tag: 'div', start: 0, end: 29, endTagStart: 23, closed: true, children: [{ tag: 'br', start: 5, end: 10, endTagStart: void 0, closed: true, children: [] }, { tag: 'span', start: 10, end: 23, endTagStart: 16, closed: true, children: [] }] }]);
 	});
 
-	test('EmptyTag', () => {
-		assertDocument('<meta>', [{ tag: 'meta', start: 0, end: 6, endTagStart: void 0, closed: true, children: [] }]);
-		assertDocument('<div><input type="button"><span><br><br></span></div>', [{
+	test('EmptyTag', async () => {
+		await assertDocument('<meta>', [{ tag: 'meta', start: 0, end: 6, endTagStart: void 0, closed: true, children: [] }]);
+		await assertDocument('<div><input type="button"><span><br><br></span></div>', [{
 			tag: 'div', start: 0, end: 53, endTagStart: 47, closed: true, children: [
 				{ tag: 'input', start: 5, end: 26, endTagStart: void 0, closed: true, children: [] },
 				{ tag: 'span', start: 26, end: 47, endTagStart: 40, closed: true, children: [{ tag: 'br', start: 32, end: 36, endTagStart: void 0, closed: true, children: [] }, { tag: 'br', start: 36, end: 40, endTagStart: void 0, closed: true, children: [] }] }
@@ -57,52 +58,52 @@ suite('HTML Parser', () => {
 		}]);
 	});
 
-	test('MissingTags', () => {
-		assertDocument('</meta>', []);
-		assertDocument('<div></div></div>', [{ tag: 'div', start: 0, end: 11, endTagStart: 5, closed: true, children: [] }]);
-		assertDocument('<div><div></div>', [{ tag: 'div', start: 0, end: 16, endTagStart: void 0, closed: false, children: [{ tag: 'div', start: 5, end: 16, endTagStart: 10, closed: true, children: [] }] }]);
-		assertDocument('<title><div></title>', [{ tag: 'title', start: 0, end: 20, endTagStart: 12, closed: true, children: [{ tag: 'div', start: 7, end: 12, endTagStart: void 0, closed: false, children: [] }] }]);
-		assertDocument('<h1><div><span></h1>', [{ tag: 'h1', start: 0, end: 20, endTagStart: 15, closed: true, children: [{ tag: 'div', start: 4, end: 15, endTagStart: void 0, closed: false, children: [{ tag: 'span', start: 9, end: 15, endTagStart: void 0, closed: false, children: [] }] }] }]);
+	test('MissingTags', async () => {
+		await assertDocument('</meta>', []);
+		await assertDocument('<div></div></div>', [{ tag: 'div', start: 0, end: 11, endTagStart: 5, closed: true, children: [] }]);
+		await assertDocument('<div><div></div>', [{ tag: 'div', start: 0, end: 16, endTagStart: void 0, closed: false, children: [{ tag: 'div', start: 5, end: 16, endTagStart: 10, closed: true, children: [] }] }]);
+		await assertDocument('<title><div></title>', [{ tag: 'title', start: 0, end: 20, endTagStart: 12, closed: true, children: [{ tag: 'div', start: 7, end: 12, endTagStart: void 0, closed: false, children: [] }] }]);
+		await assertDocument('<h1><div><span></h1>', [{ tag: 'h1', start: 0, end: 20, endTagStart: 15, closed: true, children: [{ tag: 'div', start: 4, end: 15, endTagStart: void 0, closed: false, children: [{ tag: 'span', start: 9, end: 15, endTagStart: void 0, closed: false, children: [] }] }] }]);
 	});
 
-	test('MissingBrackets', () => {
-		assertDocument('<div><div</div>', [{ tag: 'div', start: 0, end: 15, endTagStart: 9, closed: true, children: [{ tag: 'div', start: 5, end: 9, endTagStart: void 0, closed: false, children: [] }] }]);
-		assertDocument('<div><div\n</div>', [{ tag: 'div', start: 0, end: 16, endTagStart: 10, closed: true, children: [{ tag: 'div', start: 5, end: 10, endTagStart: void 0, closed: false, children: [] }] }]);
-		assertDocument('<div><div></div</div>', [{ tag: 'div', start: 0, end: 21, endTagStart: 15, closed: true, children: [{ tag: 'div', start: 5, end: 15, endTagStart: 10, closed: true, children: [] }] }]);
+	test('MissingBrackets', async () => {
+		await assertDocument('<div><div</div>', [{ tag: 'div', start: 0, end: 15, endTagStart: 9, closed: true, children: [{ tag: 'div', start: 5, end: 9, endTagStart: void 0, closed: false, children: [] }] }]);
+		await assertDocument('<div><div\n</div>', [{ tag: 'div', start: 0, end: 16, endTagStart: 10, closed: true, children: [{ tag: 'div', start: 5, end: 10, endTagStart: void 0, closed: false, children: [] }] }]);
+		await assertDocument('<div><div></div</div>', [{ tag: 'div', start: 0, end: 21, endTagStart: 15, closed: true, children: [{ tag: 'div', start: 5, end: 15, endTagStart: 10, closed: true, children: [] }] }]);
 	});
 
-	test('FindNodeBefore', () => {
+	test('FindNodeBefore', async () => {
 		const str = '<div><input type="button"><span><br><hr></span></div>';
-		assertNodeBefore(str, 0, void 0);
-		assertNodeBefore(str, 1, 'div');
-		assertNodeBefore(str, 5, 'div');
-		assertNodeBefore(str, 6, 'input');
-		assertNodeBefore(str, 25, 'input');
-		assertNodeBefore(str, 26, 'input');
-		assertNodeBefore(str, 27, 'span');
-		assertNodeBefore(str, 32, 'span');
-		assertNodeBefore(str, 33, 'br');
-		assertNodeBefore(str, 36, 'br');
-		assertNodeBefore(str, 37, 'hr');
-		assertNodeBefore(str, 40, 'hr');
-		assertNodeBefore(str, 41, 'hr');
-		assertNodeBefore(str, 42, 'hr');
-		assertNodeBefore(str, 47, 'span');
-		assertNodeBefore(str, 48, 'span');
-		assertNodeBefore(str, 52, 'span');
-		assertNodeBefore(str, 53, 'div');
+		await assertNodeBefore(str, 0, void 0);
+		await assertNodeBefore(str, 1, 'div');
+		await assertNodeBefore(str, 5, 'div');
+		await assertNodeBefore(str, 6, 'input');
+		await assertNodeBefore(str, 25, 'input');
+		await assertNodeBefore(str, 26, 'input');
+		await assertNodeBefore(str, 27, 'span');
+		await assertNodeBefore(str, 32, 'span');
+		await assertNodeBefore(str, 33, 'br');
+		await assertNodeBefore(str, 36, 'br');
+		await assertNodeBefore(str, 37, 'hr');
+		await assertNodeBefore(str, 40, 'hr');
+		await assertNodeBefore(str, 41, 'hr');
+		await assertNodeBefore(str, 42, 'hr');
+		await assertNodeBefore(str, 47, 'span');
+		await assertNodeBefore(str, 48, 'span');
+		await assertNodeBefore(str, 52, 'span');
+		await assertNodeBefore(str, 53, 'div');
 	});
 
-	test('FindNodeBefore - incomplete node', () => {
+	test('FindNodeBefore - incomplete node', async () => {
 		const str = '<div><span><br></div>';
-		assertNodeBefore(str, 15, 'br');
-		assertNodeBefore(str, 18, 'br');
-		assertNodeBefore(str, 21, 'div');
+		await assertNodeBefore(str, 15, 'br');
+		await assertNodeBefore(str, 18, 'br');
+		await assertNodeBefore(str, 21, 'div');
 	});
 
-	test('Attributes', () => {
+	test('Attributes', async () => {
 		const str = '<div class="these are my-classes" id="test"><span aria-describedby="test"></span></div>';
-		assertAttributes(str, [{
+		await assertAttributes(str, [{
 			tag: 'div',
 			attributes: {
 				class: '"these are my-classes"',
@@ -118,9 +119,9 @@ suite('HTML Parser', () => {
 		}]);
 	});
 
-	test('Attributes without value', () => {
+	test('Attributes without value', async () => {
 		const str = '<div checked id="test"></div>';
-		assertAttributes(str, [{
+		await assertAttributes(str, [{
 			tag: 'div',
 			attributes: {
 				checked: null,

--- a/src/test/pathCompletions.test.ts
+++ b/src/test/pathCompletions.test.ts
@@ -35,7 +35,7 @@ async function testCompletion2For(value: string, expected: { count?: number, ite
 
 	const context = getDocumentContext(workspaceFolderUri);
 
-	const htmlDocument = ls.parseHTMLDocument(document);
+	const htmlDocument = await ls.parseHTMLDocument(document);
 
 	const list = await ls.doComplete2(document, position, htmlDocument, context);
 

--- a/src/test/rename.test.ts
+++ b/src/test/rename.test.ts
@@ -8,7 +8,7 @@ import * as htmlLanguageService from '../htmlLanguageService';
 import { WorkspaceEdit, TextDocument } from '../htmlLanguageService';
 
 
-export function testRename(value: string, newName: string, expectedDocContent: string): void {
+export async function testRename(value: string, newName: string, expectedDocContent: string): Promise<void> {
   const offset = value.indexOf('|');
   value = value.substr(0, offset) + value.substr(offset + 1);
 
@@ -16,7 +16,7 @@ export function testRename(value: string, newName: string, expectedDocContent: s
 
   const document = TextDocument.create('test://test/test.html', 'html', 0, value);
   const position = document.positionAt(offset);
-  const htmlDoc = ls.parseHTMLDocument(document);
+  const htmlDoc = await ls.parseHTMLDocument(document);
 
   const workspaceEdit: WorkspaceEdit | null = ls.doRename(document, position, newName, htmlDoc);
 
@@ -33,7 +33,7 @@ export function testRename(value: string, newName: string, expectedDocContent: s
   assert.equal(newDocContent, expectedDocContent, `Expected: ${expectedDocContent}\nActual: ${newDocContent}`);
 }
 
-export function testNoRename(value: string, newName: string): void {
+export async function testNoRename(value: string, newName: string): Promise<void> {
   const offset = value.indexOf('|');
   value = value.substr(0, offset) + value.substr(offset + 1);
 
@@ -41,7 +41,7 @@ export function testNoRename(value: string, newName: string): void {
 
   const document = TextDocument.create('test://test/test.html', 'html', 0, value);
   const position = document.positionAt(offset);
-  const htmlDoc = ls.parseHTMLDocument(document);
+  const htmlDoc = await ls.parseHTMLDocument(document);
 
   const workspaceEdit: WorkspaceEdit | null = ls.doRename(document, position, newName, htmlDoc);
 
@@ -49,42 +49,42 @@ export function testNoRename(value: string, newName: string): void {
 }
 
 suite('HTML Rename', () => {
-  test('Rename tag', () => {
-    testRename('<|div></div>', 'h1', '<h1></h1>');
-    testRename('<d|iv></div>', 'h1', '<h1></h1>');
-    testRename('<di|v></div>', 'h1', '<h1></h1>');
-    testRename('<div|></div>', 'h1', '<h1></h1>');
-    testRename('<|div></div>', 'h1', '<h1></h1>');
-    testRename('<|div></div>', 'h1', '<h1></h1>');
+  test('Rename tag', async () => {
+    await testRename('<|div></div>', 'h1', '<h1></h1>');
+    await testRename('<d|iv></div>', 'h1', '<h1></h1>');
+    await testRename('<di|v></div>', 'h1', '<h1></h1>');
+    await testRename('<div|></div>', 'h1', '<h1></h1>');
+    await testRename('<|div></div>', 'h1', '<h1></h1>');
+    await testRename('<|div></div>', 'h1', '<h1></h1>');
 
-    testNoRename('|<div></div>', 'h1');
-    testNoRename('<div>|</div>', 'h1');
-    testNoRename('<div><|/div>', 'h1');
-    testNoRename('<div></div>|', 'h1');
+    await testNoRename('|<div></div>', 'h1');
+    await testNoRename('<div>|</div>', 'h1');
+    await testNoRename('<div><|/div>', 'h1');
+    await testNoRename('<div></div>|', 'h1');
 
-    testNoRename('<div |id="foo"></div>', 'h1');
-    testNoRename('<div i|d="foo"></div>', 'h1');
-    testNoRename('<div id|="foo"></div>', 'h1');
-    testNoRename('<div id=|"foo"></div>', 'h1');
-    testNoRename('<div id="|foo"></div>', 'h1');
-    testNoRename('<div id="f|oo"></div>', 'h1');
-    testNoRename('<div id="fo|o"></div>', 'h1');
-    testNoRename('<div id="foo|"></div>', 'h1');
-    testNoRename('<div id="foo"|></div>', 'h1');
+    await testNoRename('<div |id="foo"></div>', 'h1');
+    await testNoRename('<div i|d="foo"></div>', 'h1');
+    await testNoRename('<div id|="foo"></div>', 'h1');
+    await testNoRename('<div id=|"foo"></div>', 'h1');
+    await testNoRename('<div id="|foo"></div>', 'h1');
+    await testNoRename('<div id="f|oo"></div>', 'h1');
+    await testNoRename('<div id="fo|o"></div>', 'h1');
+    await testNoRename('<div id="foo|"></div>', 'h1');
+    await testNoRename('<div id="foo"|></div>', 'h1');
   });
 
-  test('Rename self-closing tag', () => {
-    testRename('<|br>', 'h1', `<h1>`);
-    testRename('<|br/>', 'h1', `<h1/>`);
-    testRename('<|br />', 'h1', `<h1 />`);
+  test('Rename self-closing tag', async () => {
+    await testRename('<|br>', 'h1', `<h1>`);
+    await testRename('<|br/>', 'h1', `<h1/>`);
+    await testRename('<|br />', 'h1', `<h1 />`);
   });
 
-  test('Rename inner tag', () => {
-    testRename('<div><|h1></h1></div>', 'h2', '<div><h2></h2></div>');
+  test('Rename inner tag', async () => {
+    await testRename('<div><|h1></h1></div>', 'h2', '<div><h2></h2></div>');
   });
 
-  test('Rename unmatched tag', () => {
-    testRename('<div><|h1></div>', 'h2', '<div><h2></div>');
-    testRename('<|div><h1></h1></div>', 'span', '<span><h1></h1></span>');
+  test('Rename unmatched tag', async () => {
+    await testRename('<div><|h1></div>', 'h2', '<div><h2></div>');
+    await testRename('<|div><h1></h1></div>', 'span', '<span><h1></h1></span>');
   });
 });

--- a/src/test/symbols.test.ts
+++ b/src/test/symbols.test.ts
@@ -12,37 +12,37 @@ suite('HTML Symbols', () => {
 
 	const TEST_URI = "test://test/test.html";
 
-	const testSymbolInformationsFor = function (value: string, expected: SymbolInformation[]) {
+	const testSymbolInformationsFor = async function (value: string, expected: SymbolInformation[]) {
 		const ls = htmlLanguageService.getLanguageService();
 		const document = TextDocument.create(TEST_URI, 'html', 0, value);
-		const htmlDoc = ls.parseHTMLDocument(document);
+		const htmlDoc = await ls.parseHTMLDocument(document);
 		const symbols = ls.findDocumentSymbols(document, htmlDoc);
 		assert.deepEqual(symbols, expected);
 	};
 
-	const testDocumentSymbolsFor = function (value: string, expected: DocumentSymbol[]) {
+	const testDocumentSymbolsFor = async function (value: string, expected: DocumentSymbol[]) {
 		const ls = htmlLanguageService.getLanguageService();
 		const document = TextDocument.create(TEST_URI, 'html', 0, value);
-		const htmlDoc = ls.parseHTMLDocument(document);
+		const htmlDoc = await ls.parseHTMLDocument(document);
 		const symbols = ls.findDocumentSymbols2(document, htmlDoc);
 		assert.deepEqual(symbols, expected);
 	};
 
-	test('Simple', () => {
-		testSymbolInformationsFor('<div></div>', [
+	test('Simple', async () => {
+		await testSymbolInformationsFor('<div></div>', [
 			{ containerName: '', name: 'div', kind: <SymbolKind>SymbolKind.Field, location: Location.create(TEST_URI, Range.create(0, 0, 0, 11)) }
 		]);
-		testSymbolInformationsFor('<div><input checked id="test" class="checkbox"></div>',
+		await testSymbolInformationsFor('<div><input checked id="test" class="checkbox"></div>',
 			[
 				{ containerName: '', name: 'div', kind: <SymbolKind>SymbolKind.Field, location: Location.create(TEST_URI, Range.create(0, 0, 0, 53)) },
 				{ containerName: 'div', name: 'input#test.checkbox', kind: <SymbolKind>SymbolKind.Field, location: Location.create(TEST_URI, Range.create(0, 5, 0, 47)) }
 			]
 		);
 
-		testDocumentSymbolsFor('<div></div>', [
+		await testDocumentSymbolsFor('<div></div>', [
 			DocumentSymbol.create('div', undefined, SymbolKind.Field, Range.create(0, 0, 0, 11), Range.create(0, 0, 0, 11))
 		]);
-		testDocumentSymbolsFor('<div><input checked id="test" class="checkbox"></div>',
+		await testDocumentSymbolsFor('<div><input checked id="test" class="checkbox"></div>',
 			[
 				DocumentSymbol.create('div', undefined, SymbolKind.Field, Range.create(0, 0, 0, 53), Range.create(0, 0, 0, 53), [
 					DocumentSymbol.create('input#test.checkbox', undefined, SymbolKind.Field, Range.create(0, 5, 0, 47), Range.create(0, 5, 0, 47))
@@ -51,7 +51,7 @@ suite('HTML Symbols', () => {
 		);
 	});
 
-	test('Id and classes', function () {
+	test('Id and classes', async () => {
 		const content = '<html id=\'root\'><body id="Foo" class="bar"><div class="a b"></div></body></html>';
 
 		const expected1 = [
@@ -60,7 +60,7 @@ suite('HTML Symbols', () => {
 			{ name: 'div.a.b', kind: SymbolKind.Field, containerName: 'body#Foo.bar', location: Location.create(TEST_URI, Range.create(0, 43, 0, 66)) },
 		];
 
-		testSymbolInformationsFor(content, expected1);
+		await testSymbolInformationsFor(content, expected1);
 
 		const expected2: DocumentSymbol[] = [
 			DocumentSymbol.create("html#root", undefined, SymbolKind.Field, Range.create(0, 0, 0, 80), Range.create(0, 0, 0, 80), [
@@ -69,10 +69,10 @@ suite('HTML Symbols', () => {
 				])
 			])
 		];
-		testDocumentSymbolsFor(content, expected2);
+		await testDocumentSymbolsFor(content, expected2);
 	});
 
-	test('Self closing', function () {
+	test('Self closing', async () => {
 		const content = '<html><br id="Foo"><br id=Bar></html>';
 
 		const expected1 = [
@@ -81,7 +81,7 @@ suite('HTML Symbols', () => {
 			{ name: 'br#Bar', kind: SymbolKind.Field, containerName: 'html', location: Location.create(TEST_URI, Range.create(0, 19, 0, 30)) },
 		];
 
-		testSymbolInformationsFor(content, expected1);
+		await testSymbolInformationsFor(content, expected1);
 
 		const expected2: DocumentSymbol[] = [
 			DocumentSymbol.create("html", undefined, SymbolKind.Field, Range.create(0, 0, 0, 37), Range.create(0, 0, 0, 37), [
@@ -89,10 +89,10 @@ suite('HTML Symbols', () => {
 				DocumentSymbol.create("br#Bar", undefined, SymbolKind.Field, Range.create(0, 19, 0, 30), Range.create(0, 19, 0, 30))
 			])
 		];
-		testDocumentSymbolsFor(content, expected2);
+		await testDocumentSymbolsFor(content, expected2);
 	});
 
-	test('No attrib', function () {
+	test('No attrib', async () => {
 		const content = '<html><body><div></div></body></html>';
 
 		const expected = [
@@ -101,7 +101,7 @@ suite('HTML Symbols', () => {
 			{ name: 'div', kind: SymbolKind.Field, containerName: 'body', location: Location.create(TEST_URI, Range.create(0, 12, 0, 23)) }
 		];
 
-		testSymbolInformationsFor(content, expected);
+		await testSymbolInformationsFor(content, expected);
 
 		const expected2: DocumentSymbol[] = [
 			DocumentSymbol.create("html", undefined, SymbolKind.Field, Range.create(0, 0, 0, 37), Range.create(0, 0, 0, 37), [
@@ -110,6 +110,6 @@ suite('HTML Symbols', () => {
 				])
 			])
 		];
-		testDocumentSymbolsFor(content, expected2);
+		await testDocumentSymbolsFor(content, expected2);
 	});
 });


### PR DESCRIPTION
A common requirement is to send requests to the TS server to fetch tags, attributes or values. However, the current APIs do not support asynchronous operations, which forces us to use a quite dirty way to fetch asynchronous data:

https://github.com/vuejs/language-tools/blob/5ae4b381de01e3e9c0723fd4c5a74c1cbcc6ba78/packages/language-service/lib/plugins/vue-template.ts#L507-L522

https://github.com/vuejs/language-tools/blob/5ae4b381de01e3e9c0723fd4c5a74c1cbcc6ba78/packages/language-service/lib/plugins/vue-template.ts#L170-L185

This PR makes `provideTags`, `provideAttributes` and `provideValues` asynchronous, while also causing many other APIs to become asynchronous.