### PR TITLE
Add setting to disable end tag suggestions

### DIFF
--- a/src/htmlLanguageTypes.ts
+++ b/src/htmlLanguageTypes.ts
@@ -57,6 +57,7 @@ export interface HoverSettings {
 export interface CompletionConfiguration {
 	[provider: string]: boolean | undefined | string;
 	hideAutoCompleteProposals?: boolean;
+	hideEndTagSuggestions?: boolean;
 	attributeDefaultValue?: 'empty' | 'singlequotes' | 'doublequotes';
 }
 

--- a/src/services/htmlCompletion.ts
+++ b/src/services/htmlCompletion.ts
@@ -118,6 +118,9 @@ export class HTMLCompletion {
 		}
 
 		function collectCloseTagSuggestions(afterOpenBracket: number, inOpenTag: boolean, tagNameEnd: number = offset): CompletionList {
+			if (settings && settings.hideEndTagSuggestions) {
+				return result;
+			}
 			const range = getReplaceRange(afterOpenBracket, tagNameEnd);
 			const closeTag = isFollowedBy(text, tagNameEnd, ScannerState.WithinEndTag, TokenType.EndTagClose) ? '' : '>';
 			let curr: Node | undefined = node;

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -509,4 +509,39 @@ suite('HTML Completion', () => {
 			items: [{ label: '/a', resultText: '<div></div></a>' }]
 		});
 	});
+
+	test('Hide end tag suggestions setting', () => {
+		// Default behavior - end tag suggestions should be shown
+		testCompletionFor('<body>\n<|', {
+			items: [
+				{ label: '/body' },
+				{ label: 'div' }
+			]
+		});
+
+		// With hideEndTagSuggestions enabled - end tag suggestions should be hidden
+		testCompletionFor('<body>\n<|', {
+			items: [
+				{ label: '/body', notAvailable: true },
+				{ label: 'div' }
+			]
+		}, { hideEndTagSuggestions: true });
+
+		// With hideEndTagSuggestions and html5 disabled - no suggestions
+		testCompletionFor('<body>\n<|', {
+			items: [
+				{ label: '/body', notAvailable: true },
+				{ label: 'div', notAvailable: true }
+			]
+		}, { hideEndTagSuggestions: true, html5: false });
+
+		// Close tag suggestions in different contexts
+		testCompletionFor('<div>\n  <|\n</div>', {
+			items: [{ label: '/div', notAvailable: true }]
+		}, { hideEndTagSuggestions: true });
+
+		testCompletionFor('</|', {
+			items: [{ label: '/a', notAvailable: true }]
+		}, { hideEndTagSuggestions: true });
+	});
 });


### PR DESCRIPTION
Fixes #216

## Summary

This PR introduces a new `hideEndTagSuggestions` configuration option that allows users to disable closing tag suggestions in HTML completions.

## Problem

Currently, the `html.suggest.html5` setting controls whether HTML5 tags, properties, and values are suggested, but it does not affect closing tag suggestions (e.g., `</div>`). When a user types `<` in an HTML document, they see both regular tag suggestions and end tag completions for unclosed tags.

Users who want to disable all HTML suggestions have no way to turn off these end tag completions without disabling the entire extension. This is particularly important for users of alternative HTML tools (like SuperHTML mentioned in the issue) who want to use VS Code's editor features but prefer to use a different tool for HTML completions.

## Solution

This PR adds a new `hideEndTagSuggestions` boolean option to the `CompletionConfiguration` interface. When set to `true`, the language service will not provide end tag suggestions.

### Changes Made

#### vscode-html-languageservice
1. **htmlLanguageTypes.ts**: Added `hideEndTagSuggestions?: boolean` to the `CompletionConfiguration` interface
2. **htmlCompletion.ts**: Updated `collectCloseTagSuggestions` function to check the setting and return early if disabled
3. **completion.test.ts**: Added comprehensive tests covering various scenarios with the new setting

#### vscode (VS Code Extension)
1. **package.json**: Added new configuration setting `html.suggest.hideEndTagSuggestions` with default value `false`
2. **package.nls.json**: Added localized description for the new setting

## Testing

The implementation includes comprehensive test coverage:
- Default behavior (end tags shown) remains unchanged
- When `hideEndTagSuggestions: true`, no end tag suggestions appear
- Works correctly in combination with other settings (e.g., `html5: false`)
- Tests various contexts: nested tags, indented tags, and standalone close tags

All existing tests continue to pass, ensuring backward compatibility.

## Backward Compatibility

The setting defaults to `false`, meaning end tag suggestions are shown by default. This maintains the current behavior for all existing users. Only users who explicitly enable this setting will see the change in behavior.

## Usage

Users can add this to their VS Code settings to disable end tag suggestions:

```json
{
  "html.suggest.hideEndTagSuggestions": true
}
```

This can be combined with disabling HTML5 suggestions for a minimal suggestion experience:

```json
{
  "html.suggest.html5": false,
  "html.suggest.hideEndTagSuggestions": true
}
```
