### PR TITLE
fix: clamp format result range to document bounds (#153)

### DIFF
--- a/src/services/htmlFormatter.ts
+++ b/src/services/htmlFormatter.ts
@@ -92,6 +92,14 @@ export function format(document: TextDocument, range: Range | undefined, options
 			result = indent + result; // keep the indent
 		}
 	}
+	if (result === value) {
+		return [];
+	}
+	// Clamp the range end to the document end to avoid returning a range that exceeds the document length
+	const documentEnd = document.positionAt(document.getText().length);
+	if (range.end.line > documentEnd.line || (range.end.line === documentEnd.line && range.end.character > documentEnd.character)) {
+		range = Range.create(range.start, documentEnd);
+	}
 	return [{
 		range: range,
 		newText: result

--- a/src/test/formatter.test.ts
+++ b/src/test/formatter.test.ts
@@ -574,3 +574,53 @@ suite('HTML Formatter - Embedded CSS', () => {
 	});
 
 });
+
+suite('HTML Formatter - Range validation', () => {
+
+	function assertRangeWithinDocument(content: string, options?: HTMLFormatConfiguration) {
+		const uri = 'test://test.html';
+		const document = TextDocument.create(uri, 'html', 0, content);
+		const formatOptions = options ?? { tabSize: 2, insertSpaces: true };
+		const edits = getLanguageService().format(document, undefined, formatOptions);
+		const documentEnd = document.positionAt(content.length);
+		for (const edit of edits) {
+			assert.ok(
+				edit.range.end.line < documentEnd.line ||
+				(edit.range.end.line === documentEnd.line && edit.range.end.character <= documentEnd.character),
+				`Edit range end (${edit.range.end.line}, ${edit.range.end.character}) exceeds document end (${documentEnd.line}, ${documentEnd.character}) for content ${JSON.stringify(content)}`
+			);
+		}
+		return edits;
+	}
+
+	test('empty document returns no edits', () => {
+		const edits = assertRangeWithinDocument('');
+		assert.strictEqual(edits.length, 0, 'Expected no edits for an empty document');
+	});
+
+	test('whitespace-only document returns valid range', () => {
+		assertRangeWithinDocument('   ');
+	});
+
+	test('newline-only document returns valid range', () => {
+		assertRangeWithinDocument('\n');
+	});
+
+	test('CRLF-only document returns valid range', () => {
+		assertRangeWithinDocument('\r\n');
+	});
+
+	test('empty document with endWithNewline returns valid range', () => {
+		const edits = assertRangeWithinDocument('', { tabSize: 2, insertSpaces: true, endWithNewline: true });
+		// endWithNewline on empty document should produce a valid edit
+		if (edits.length > 0) {
+			assert.strictEqual(edits[0].newText, '\n');
+		}
+	});
+
+	test('already formatted document returns no edits', () => {
+		const edits = assertRangeWithinDocument('<div>\n  <br>\n</div>');
+		assert.strictEqual(edits.length, 0, 'Expected no edits for already formatted content');
+	});
+
+});


### PR DESCRIPTION
## Summary

Fixes #153

**Bug:** `format` could return a `TextEdit` with a range end exceeding the document length, causing downstream consumers to fail.

**Root Cause:** The formatter used the initial full-document range (lines 0 to `MAX_VALUE`) without clamping it back to actual document bounds before returning, and also returned a redundant edit when formatting produced no changes.

**Fix:** Added a no-op optimization that returns an empty array when the formatted result equals the original text, and added defensive range clamping that limits the edit range end to the document's actual end position.

## Changes

- `src/services/htmlFormatter.ts`: Return early with `[]` when formatted output matches input; clamp `range.end` to `document.positionAt(text.length)` before constructing the returned `TextEdit`.
- `src/test/formatter.test.ts`: Added 6 regression tests covering empty documents, whitespace-only, newline-only, CRLF-only, `endWithNewline` on empty input, and already-formatted content — all asserting edit ranges stay within document bounds.

## Testing

- Added regression tests in `src/test/formatter.test.ts` that verify all returned edit ranges do not exceed document length
- All 161 existing tests pass