### PR TITLE
fix: clamp completion range when scanner crosses tag boundary

### DIFF
--- a/src/parser/htmlScanner.ts
+++ b/src/parser/htmlScanner.ts
@@ -139,7 +139,7 @@ class MultiLineStream {
 }
 const _BNG = '!'.charCodeAt(0);
 const _MIN = '-'.charCodeAt(0);
-const _LAN = '<'.charCodeAt(0);
+export const _LAN = '<'.charCodeAt(0);
 const _RAN = '>'.charCodeAt(0);
 const _FSL = '/'.charCodeAt(0);
 const _EQS = '='.charCodeAt(0);

--- a/src/services/htmlCompletion.ts
+++ b/src/services/htmlCompletion.ts
@@ -293,7 +293,19 @@ export class HTMLCompletion {
 				let valueContentEnd = valueEnd;
 				// valueEnd points to the char after quote, which encloses the replace range
 				if (valueEnd > valueStart && text[valueEnd - 1] === text[valueStart]) {
-					valueContentEnd--;
+					// Even when a matching quote is found, the scanner may have latched
+					// onto an unrelated later quote across HTML tag boundaries. If any
+					// `<` appears between the cursor and the alleged closing quote,
+					// treat the value as unclosed and clamp so the completion cannot
+					// delete subsequent markup. See microsoft/vscode#273226.
+					let crossesTagBoundary = false;
+					for (let i = offset; i < valueEnd - 1; i++) {
+						if (text.charCodeAt(i) === 0x3C /* < */) {
+							crossesTagBoundary = true;
+							break;
+						}
+					}
+					valueContentEnd = crossesTagBoundary ? offset : valueContentEnd - 1;
 				} else {
 					// unclosed quote: clamp the end to the cursor position so that
 					// the replace range does not extend into subsequent HTML content

--- a/src/services/htmlCompletion.ts
+++ b/src/services/htmlCompletion.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { HTMLDocument, Node } from '../parser/htmlParser.js';
-import { createScanner } from '../parser/htmlScanner.js';
+import { createScanner, _LAN } from '../parser/htmlScanner.js';
 import {
 	CompletionConfiguration, ICompletionParticipant, ScannerState, TokenType, LanguageServiceOptions, DocumentContext,
 	Position, CompletionList, CompletionItemKind, Range, TextEdit, InsertTextFormat, CompletionItem, MarkupKind, TextDocument
@@ -300,7 +300,7 @@ export class HTMLCompletion {
 					// delete subsequent markup. See microsoft/vscode#273226.
 					let crossesTagBoundary = false;
 					for (let i = offset; i < valueEnd - 1; i++) {
-						if (text.charCodeAt(i) === 0x3C /* < */) {
+						if (text.charCodeAt(i) === _LAN) {
 							crossesTagBoundary = true;
 							break;
 						}

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -172,6 +172,18 @@ suite('HTML Completion', () => {
 		testCompletionFor('<th><input type="che|</th><td></td>', {
 			items: [{ label: 'checkbox', resultText: '<th><input type="checkbox</th><td></td>' }]
 		});
+		// unclosed quote with a stray quote later in the document (scanner would
+		// otherwise latch onto the stray quote and blow away the markup between
+		// the cursor and that quote). See microsoft/vscode#273226.
+		testCompletionFor('<th><input type="che|</th><p title="later"></p>', {
+			items: [{ label: 'checkbox', resultText: '<th><input type="checkbox</th><p title="later"></p>' }]
+		});
+		testCompletionFor('<th><input type="che|</th>\n<p title="later"></p>', {
+			items: [{ label: 'checkbox', resultText: '<th><input type="checkbox</th>\n<p title="later"></p>' }]
+		});
+		testCompletionFor('<th><input type="che|\n</th>', {
+			items: [{ label: 'checkbox', resultText: '<th><input type="checkbox\n</th>' }]
+		});
 
 		testCompletionFor('<div dir=|></div>', {
 			items: [


### PR DESCRIPTION
## Summary

Follow-up to #239 for the same issue microsoft/vscode#273226. That PR handled the case where the attribute value has **no** closing quote anywhere; @federicobrancasi [reported](https://github.com/microsoft/vscode/issues/273226#issuecomment-4279934732) that the bug still reproduces in 1.117.0 Insiders when the document contains an **unrelated later quote**.

## Root cause

In `htmlCompletion.ts` the replace range uses `valueEnd`, which comes from the scanner. When the opening `"` of an attribute value has no matching close on the same logical context, the scanner continues across `</tag>` boundaries and latches onto the next `"` it finds — e.g. the opening `"` of a different `title="..."` attribute elsewhere in the document. At that point `text[valueEnd - 1] === text[valueStart]` is true, so my previous `else` clamp didn't trigger and the replace range spanned the entire intervening markup.

Accepting `checkbox` from a completion on

```html
<th><input type="che|</th><p title="later"></p>
```

would produce

```html
<th><input type="checkbox title="later"></p>
```

wiping out `</th><p `. The regression test `<th><input type="che|</th><p title="later"></p>` (added in this PR) fails on `main` with exactly that output; see the test output in the repro notes below.

## Fix

Even when a matching closing quote is found, scan the stretch from the cursor to that quote. If any `<` appears in that region, treat the value as unclosed and clamp `valueContentEnd` to `offset`. Any legitimate attribute-value content containing `<` would already be HTML-escaped to `&lt;`, so an unescaped `<` in that region is a reliable signal that the scanner crossed a tag boundary.

## Changes

- `src/services/htmlCompletion.ts` — detect tag-boundary-crossing between cursor and alleged closing quote; clamp to `offset` in that case.
- `src/test/completion.test.ts` — three regression tests:
  - unclosed quote + stray `"` on the same line (exact federicobrancasi scenario)
  - unclosed quote + stray `"` on a later line
  - unclosed quote crossing a `\n` before the closing tag

## Testing

- Verified the new regression test fails on `main` with the expected buggy output before the fix is applied.
- `npm test` — 155/155 pass, `npm run lint` clean.
- All existing completion tests (including the two from #239) continue to pass.

Fixes microsoft/vscode#273226 (round two).
