### PR TITLE
Anchor the #endregion folding marker

### DIFF
--- a/src/services/htmlFolding.ts
+++ b/src/services/htmlFolding.ts
@@ -140,7 +140,10 @@ export class HTMLFolding {
 				case TokenType.Comment: {
 					let startLine = document.positionAt(scanner.getTokenOffset()).line;
 					const text = scanner.getTokenText();
-					const m = text.match(/^\s*#(region\b)|(endregion\b)/);
+					// Both markers have to be anchored: without the group the `^\s*#`
+					// applies only to the first alternative, so any comment merely
+					// containing the word "endregion" closed the open region.
+					const m = text.match(/^\s*#(?:(region\b)|(endregion\b))/);
 					if (m) {
 						if (m[1]) { // start pattern match
 							stack.push({ startLine, tagName: '' }); // empty tagName marks region

--- a/src/test/folding.test.ts
+++ b/src/test/folding.test.ts
@@ -107,6 +107,31 @@ suite('HTML Folding', () => {
 		assertRanges(input, [r(0, 3, 'region'), r(1, 2, 'region')]);
 	});
 
+	test('Fold regions - a comment merely mentioning endregion does not close one', () => {
+		const input = [
+			/*0*/'<!-- #region -->',
+			/*1*/'<div>',
+			/*2*/'</div>',
+			/*3*/'<!--',
+			/*4*/'  the endregion marker closes it',
+			/*5*/'-->',
+			/*6*/'<p>x</p>',
+			/*7*/'<!-- #endregion -->',
+		];
+		assertRanges(input, [r(0, 7, 'region'), r(3, 5, 'comment')]);
+	});
+
+	test('Fold comment - containing the word endregion stays foldable', () => {
+		const input = [
+			/*0*/'<!--',
+			/*1*/'  line one',
+			/*2*/'  endregion appears here',
+			/*3*/'  line three',
+			/*4*/'-->',
+		];
+		assertRanges(input, [r(0, 4, 'comment')]);
+	});
+
 
 
 	test('Fold incomplete', () => {


### PR DESCRIPTION
## Problem

`htmlFolding.ts` detects region markers with:

```ts
const m = text.match(/^\s*#(region\b)|(endregion\b)/);
```

Alternation binds looser than the anchor, so this reads as `(^\s*#region\b)` **or** `(endregion\b)` — the second branch is unanchored and matches the word anywhere in a comment.

## Effect

Measured with `getFoldingRanges` on the built library:

| input | ranges |
|---|---|
| `#region` … a harmless multi-line comment … `#endregion` | `{3-5 comment}, {0-7 region}` ✓ |
| the same, with the comment containing the word *endregion* | `{0-3 region}` ✗ |
| a standalone multi-line comment | `{0-4 comment}` ✓ |
| the same comment containing the word *endregion* | `[]` ✗ |

Two things go wrong at once. The open `#region` is closed at the prose comment instead of at its real marker, so the fold covers the wrong span; and because that comment was consumed as a marker, it also loses its own folding range.

An HTML comment that documents region markers — or any prose that happens to contain the word — is enough to trigger it.

## Fix

Group the alternation so the anchor covers both branches:

```ts
const m = text.match(/^\s*#(?:(region\b)|(endregion\b))/);
```

Capture-group numbering is unchanged, so the `m[1]` / `m[2]` branches below need no edit.

## Test plan

- Added two cases to `src/test/folding.test.ts` beside the existing `Fold regions`: a region whose body contains a comment mentioning *endregion*, and a standalone comment containing the word.
- Ran: `node --test ./lib/esm/test/*.test.js` → **178 passing** (176 before).
- Checked: reverting only `htmlFolding.ts` fails both new tests.
- Ran: `npm run lint` → clean.